### PR TITLE
Feature/#7 ReviewSelectingView 제작

### DIFF
--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		32E9A561292E68CF000072EE /* DetailReview+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A560292E68CF000072EE /* DetailReview+User.swift */; };
 		32E9A563292E6A56000072EE /* DetailReviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A562292E6A56000072EE /* DetailReviewTableViewCell.swift */; };
 		32E9A565292E704A000072EE /* DetailReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A564292E704A000072EE /* DetailReviewViewModel.swift */; };
+		32E9A567292F24EF000072EE /* ReviewSelectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A566292F24EF000072EE /* ReviewSelectingView.swift */; };
+		32E9A569292F2509000072EE /* ReviewSelectingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +73,8 @@
 		32E9A560292E68CF000072EE /* DetailReview+User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DetailReview+User.swift"; sourceTree = "<group>"; };
 		32E9A562292E6A56000072EE /* DetailReviewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailReviewTableViewCell.swift; sourceTree = "<group>"; };
 		32E9A564292E704A000072EE /* DetailReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailReviewViewModel.swift; sourceTree = "<group>"; };
+		32E9A566292F24EF000072EE /* ReviewSelectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingView.swift; sourceTree = "<group>"; };
+		32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingCollectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -175,6 +179,8 @@
 			children = (
 				3244A1FF292DC13A00716A2B /* ViewController.swift */,
 				32E9A556292E195E000072EE /* TagReviewView.swift */,
+				32E9A566292F24EF000072EE /* ReviewSelectingView.swift */,
+				32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */,
 				32E9A55A292E24D2000072EE /* TagReviewViewModel.swift */,
 				32E9A558292E1AFE000072EE /* VotedTagCollectionView.swift */,
 				32E9A55C292E4F37000072EE /* VotedTagCollectionViewCell.swift */,
@@ -364,6 +370,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32E9A567292F24EF000072EE /* ReviewSelectingView.swift in Sources */,
+				32E9A569292F2509000072EE /* ReviewSelectingCollectionView.swift in Sources */,
 				32E9A563292E6A56000072EE /* DetailReviewTableViewCell.swift in Sources */,
 				32E9A55D292E4F37000072EE /* VotedTagCollectionViewCell.swift in Sources */,
 				32E9A555292E1947000072EE /* TagReview.swift in Sources */,

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		32E9A565292E704A000072EE /* DetailReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A564292E704A000072EE /* DetailReviewViewModel.swift */; };
 		32E9A567292F24EF000072EE /* ReviewSelectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A566292F24EF000072EE /* ReviewSelectingView.swift */; };
 		32E9A569292F2509000072EE /* ReviewSelectingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */; };
+		32E9A56B292F25B7000072EE /* ReviewSelectingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A56A292F25B7000072EE /* ReviewSelectingViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +76,7 @@
 		32E9A564292E704A000072EE /* DetailReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailReviewViewModel.swift; sourceTree = "<group>"; };
 		32E9A566292F24EF000072EE /* ReviewSelectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingView.swift; sourceTree = "<group>"; };
 		32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingCollectionView.swift; sourceTree = "<group>"; };
+		32E9A56A292F25B7000072EE /* ReviewSelectingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,14 +181,15 @@
 			children = (
 				3244A1FF292DC13A00716A2B /* ViewController.swift */,
 				32E9A556292E195E000072EE /* TagReviewView.swift */,
-				32E9A566292F24EF000072EE /* ReviewSelectingView.swift */,
-				32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */,
 				32E9A55A292E24D2000072EE /* TagReviewViewModel.swift */,
 				32E9A558292E1AFE000072EE /* VotedTagCollectionView.swift */,
 				32E9A55C292E4F37000072EE /* VotedTagCollectionViewCell.swift */,
 				32E9A564292E704A000072EE /* DetailReviewViewModel.swift */,
 				32E9A55E292E64DC000072EE /* DetailReviewTableView.swift */,
 				32E9A562292E6A56000072EE /* DetailReviewTableViewCell.swift */,
+				32E9A566292F24EF000072EE /* ReviewSelectingView.swift */,
+				32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */,
+				32E9A56A292F25B7000072EE /* ReviewSelectingViewModel.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32E9A56B292F25B7000072EE /* ReviewSelectingViewModel.swift in Sources */,
 				32E9A567292F24EF000072EE /* ReviewSelectingView.swift in Sources */,
 				32E9A569292F2509000072EE /* ReviewSelectingCollectionView.swift in Sources */,
 				32E9A563292E6A56000072EE /* DetailReviewTableViewCell.swift in Sources */,

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		32E9A567292F24EF000072EE /* ReviewSelectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A566292F24EF000072EE /* ReviewSelectingView.swift */; };
 		32E9A569292F2509000072EE /* ReviewSelectingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */; };
 		32E9A56B292F25B7000072EE /* ReviewSelectingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A56A292F25B7000072EE /* ReviewSelectingViewModel.swift */; };
+		32E9A56D292F295B000072EE /* TagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E9A56C292F295B000072EE /* TagCollectionViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		32E9A566292F24EF000072EE /* ReviewSelectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingView.swift; sourceTree = "<group>"; };
 		32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingCollectionView.swift; sourceTree = "<group>"; };
 		32E9A56A292F25B7000072EE /* ReviewSelectingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSelectingViewModel.swift; sourceTree = "<group>"; };
+		32E9A56C292F295B000072EE /* TagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCollectionViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,6 +191,7 @@
 				32E9A562292E6A56000072EE /* DetailReviewTableViewCell.swift */,
 				32E9A566292F24EF000072EE /* ReviewSelectingView.swift */,
 				32E9A568292F2509000072EE /* ReviewSelectingCollectionView.swift */,
+				32E9A56C292F295B000072EE /* TagCollectionViewCell.swift */,
 				32E9A56A292F25B7000072EE /* ReviewSelectingViewModel.swift */,
 			);
 			path = Presentation;
@@ -382,6 +385,7 @@
 				3244A200292DC13A00716A2B /* ViewController.swift in Sources */,
 				32E9A559292E1AFE000072EE /* VotedTagCollectionView.swift in Sources */,
 				32E9A55F292E64DC000072EE /* DetailReviewTableView.swift in Sources */,
+				32E9A56D292F295B000072EE /* TagCollectionViewCell.swift in Sources */,
 				32E9A557292E195E000072EE /* TagReviewView.swift in Sources */,
 				32E9A561292E68CF000072EE /* DetailReview+User.swift in Sources */,
 				3244A1FC292DC13A00716A2B /* AppDelegate.swift in Sources */,

--- a/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -31,7 +31,9 @@
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "28"
-            endingLineNumber = "28">
+            endingLineNumber = "28"
+            landmarkName = "viewDidLoad()"
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -93,7 +95,9 @@
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "37"
-            endingLineNumber = "37">
+            endingLineNumber = "37"
+            landmarkName = "ViewController"
+            landmarkType = "3">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -107,7 +111,9 @@
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "37"
-            endingLineNumber = "37">
+            endingLineNumber = "37"
+            landmarkName = "ViewController"
+            landmarkType = "3">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -168,8 +174,8 @@
             filePath = "RefillStation/Presentation/ReviewSelectingCollectionView.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "49"
-            endingLineNumber = "49"
+            startingLineNumber = "50"
+            endingLineNumber = "50"
             landmarkName = "collectionView(_:numberOfItemsInSection:)"
             landmarkType = "7">
          </BreakpointContent>

--- a/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -92,8 +92,8 @@
             filePath = "RefillStation/Presentation/ViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "38"
-            endingLineNumber = "38">
+            startingLineNumber = "37"
+            endingLineNumber = "37">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -155,6 +155,22 @@
             startingLineNumber = "40"
             endingLineNumber = "40"
             landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "5228DD9B-8F86-4A00-BE87-E0C8EDE74C3F"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/ReviewSelectingCollectionView.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "49"
+            endingLineNumber = "49"
+            landmarkName = "collectionView(_:numberOfItemsInSection:)"
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
@@ -10,10 +10,11 @@ import SnapKit
 
 final class ReviewSelectingCollectionView: UICollectionView {
 
-    var viewModel: ReviewSelectingViewModel!
+    var viewModel: ReviewSelectingViewModel
 
-    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
-        super.init(frame: frame, collectionViewLayout: layout)
+    init(viewModel: ReviewSelectingViewModel) {
+        self.viewModel = viewModel
+        super.init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         self.collectionViewLayout = compositionalLayout()
         dataSource = self
         delegate = self

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
@@ -64,10 +64,7 @@ extension ReviewSelectingCollectionView: UICollectionViewDataSource {
 
 extension ReviewSelectingCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        guard let selectedCount = collectionView.indexPathsForSelectedItems?.count else {
-            return false
-        }
-
-        return selectedCount < 3
+        guard let selectedItems = collectionView.indexPathsForSelectedItems else { return false }
+        return selectedItems.count < 3
     }
 }

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
@@ -15,6 +15,10 @@ final class ReviewSelectingCollectionView: UICollectionView {
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
         self.collectionViewLayout = compositionalLayout()
+        dataSource = self
+        delegate = self
+        allowsMultipleSelection = true
+        register(TagCollectionViewCell.self, forCellWithReuseIdentifier: TagCollectionViewCell.reuseIdentifier)
     }
 
     required init?(coder: NSCoder) {
@@ -25,10 +29,13 @@ final class ReviewSelectingCollectionView: UICollectionView {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .fractionalHeight(1/4))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(3/5),
+        item.contentInsets = .init(top: 5, leading: 5, bottom: 5, trailing: 5)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(7/10),
                                                heightDimension: .fractionalHeight(1))
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 10
+        section.orthogonalScrollingBehavior = .continuous
 
         return UICollectionViewCompositionalLayout(section: section)
     }
@@ -43,6 +50,23 @@ extension ReviewSelectingCollectionView: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return UICollectionViewCell()
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: TagCollectionViewCell.reuseIdentifier,
+            for: indexPath) as? TagCollectionViewCell else { return UICollectionViewCell() }
+
+        cell.setUpContents(title: viewModel.reviews[indexPath.row].tagTitle)
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension ReviewSelectingCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let selectedCount = collectionView.indexPathsForSelectedItems?.count else {
+            return false
+        }
+
+        return selectedCount < 3
     }
 }

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
@@ -1,0 +1,24 @@
+//
+//  ReviewSelectingCollectionView.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2022/11/24.
+//
+
+import UIKit
+import SnapKit
+
+final class ReviewSelectingCollectionView: UICollectionView {
+
+}
+
+extension ReviewSelectingCollectionView: UICollectionViewDataSource {
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 0
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return UICollectionViewCell()
+    }
+}

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingCollectionView.swift
@@ -10,12 +10,36 @@ import SnapKit
 
 final class ReviewSelectingCollectionView: UICollectionView {
 
+    var viewModel: ReviewSelectingViewModel!
+
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        self.collectionViewLayout = compositionalLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func compositionalLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                              heightDimension: .fractionalHeight(1/4))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(3/5),
+                                               heightDimension: .fractionalHeight(1))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
 }
+
+// MARK: - UICollectionViewDataSource
 
 extension ReviewSelectingCollectionView: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 0
+        return viewModel.reviews.count
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingView.swift
@@ -1,0 +1,13 @@
+//
+//  ReviewSelectingView.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2022/11/24.
+//
+
+import UIKit
+import SnapKit
+
+final class ReviewSelectingView: UIView {
+
+}

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingView.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingView.swift
@@ -10,4 +10,50 @@ import SnapKit
 
 final class ReviewSelectingView: UIView {
 
+    var viewModel: ReviewSelectingViewModel
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "이 매장의 좋은 점은 무엇인가요?"
+        return label
+    }()
+
+    private let maximumSelectLabel: UILabel = {
+        let label = UILabel()
+        label.text = "최대 3개"
+        return label
+    }()
+
+    private let reviewSelectingCollectionView: ReviewSelectingCollectionView
+
+    init(viewModel: ReviewSelectingViewModel) {
+        self.viewModel = viewModel
+        self.reviewSelectingCollectionView = ReviewSelectingCollectionView(viewModel: viewModel)
+        super.init(frame: .zero)
+        layout()
+    }
+
+    required init?(coder: NSCoder) {
+        self.viewModel = ReviewSelectingViewModel()
+        self.reviewSelectingCollectionView = ReviewSelectingCollectionView(viewModel: viewModel)
+        super.init(coder: coder)
+    }
+
+    private func layout() {
+        [titleLabel, maximumSelectLabel, reviewSelectingCollectionView].forEach { addSubview($0) }
+
+        titleLabel.snp.makeConstraints { title in
+            title.leading.top.equalTo(self).inset(10)
+        }
+
+        maximumSelectLabel.snp.makeConstraints { maxLabel in
+            maxLabel.leading.equalTo(titleLabel.snp.trailing).offset(10)
+            maxLabel.top.trailing.equalTo(self).inset(10)
+        }
+
+        reviewSelectingCollectionView.snp.makeConstraints { collection in
+            collection.top.equalTo(titleLabel.snp.bottom).offset(10)
+            collection.leading.trailing.bottom.equalTo(self).inset(10)
+        }
+    }
 }

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingViewModel.swift
@@ -9,5 +9,5 @@ import Foundation
 
 final class ReviewSelectingViewModel {
 
-    var reviews = [TagReviewView]()
+    var reviews = [TagReview]()
 }

--- a/RefillStation/RefillStation/Presentation/ReviewSelectingViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/ReviewSelectingViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  ReviewSelectingViewModel.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2022/11/24.
+//
+
+import Foundation
+
+final class ReviewSelectingViewModel {
+
+    var reviews = [TagReviewView]()
+}

--- a/RefillStation/RefillStation/Presentation/TagCollectionViewCell.swift
+++ b/RefillStation/RefillStation/Presentation/TagCollectionViewCell.swift
@@ -12,6 +12,16 @@ final class TagCollectionViewCell: UICollectionViewCell {
 
     static let reuseIdentifier = "tagCollectionViewCell"
 
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                contentView.backgroundColor = .lightGray
+            } else {
+                contentView.backgroundColor = .white
+            }
+        }
+    }
+
     private let tagTitleLabel: UILabel = {
         let label = UILabel()
         return label

--- a/RefillStation/RefillStation/Presentation/TagCollectionViewCell.swift
+++ b/RefillStation/RefillStation/Presentation/TagCollectionViewCell.swift
@@ -1,0 +1,46 @@
+//
+//  TagCollectionViewCell.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2022/11/24.
+//
+
+import UIKit
+import SnapKit
+
+final class TagCollectionViewCell: UICollectionViewCell {
+
+    static let reuseIdentifier = "tagCollectionViewCell"
+
+    private let tagTitleLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        makeContentViewLayer()
+        layout()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    func setUpContents(title: String) {
+        tagTitleLabel.text = title
+    }
+
+    private func makeContentViewLayer() {
+        contentView.layer.cornerRadius = 5
+        contentView.layer.borderWidth = 1
+        contentView.layer.borderColor = UIColor.gray.cgColor
+    }
+
+    private func layout() {
+        contentView.addSubview(tagTitleLabel)
+        tagTitleLabel.snp.makeConstraints { tag in
+            tag.edges.equalTo(contentView).inset(5)
+        }
+    }
+}


### PR DESCRIPTION
## 🧴 PR 요약
ReviewSelectingView를 제작하였습니다.
단발성 데이터를 가지고 tag목록을 만들기 때문에 UICollectionViewDataSource를,
세로로 4개의 tag가 들어가되 가로 스크롤이 되도록 만들기 위해 UICollectionViewCompositionalLayout를 사용했습니다.

이전 PR에서는 string을 서버로부터 받아올지도 모른다 생각하여 setUpContents에서 label.text를 지정하도록 하였었는데
서버로부터 받아올 확률이 거의 없다고 판단하게 되어 이번 PR부터는 생성시점에 text를 지정하도록 했습니다.
이전 작업내역들에 대해서는 리팩토링을 통해 일관성을 가지도록 할 예정입니다.

최대 3개까지만 select되도록 하기 위해 UICollectionViewDelegate의
collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) 메서드를
사용하였습니다.

viewModel 주입의 경우 아직 DIContainer 내부의 작업을 확정짓지 않았기 때문에
각 PR마다 주입방법에서 조금씩 차이가 발생하고 있는데
DIContainer 제작시점에 해결될 문제이므로 지금은 view 제작에 집중하였습니다.

##### 📸 ScreenShot
![ReviewSelectingView PR](https://user-images.githubusercontent.com/67148595/203702445-2875546f-3e67-4bff-8d6d-83537617b097.gif)


#### Linked Issue
#7
