### PR TITLE
Feature #12 불필요한 이니셜라이저 삭제

### DIFF
--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/ProductTableView.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/ProductTableView.swift
@@ -13,20 +13,12 @@ final class ProductTableView: UITableView {
     private var viewModel: StoreDetailViewModel!
 
     // MARK: - Initializer
-    override init(frame: CGRect, style: UITableView.Style) {
-        super.init(frame: frame, style: style)
-        register(ProductTableViewCell.self,
-                 forCellReuseIdentifier: ProductTableViewCell.reuseIdentifier)
-        dataSource = self
-    }
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-
     convenience init(viewModel: StoreDetailViewModel) {
         self.init()
         self.viewModel = viewModel
+        register(ProductTableViewCell.self,
+                 forCellReuseIdentifier: ProductTableViewCell.reuseIdentifier)
+        dataSource = self
     }
 }
 


### PR DESCRIPTION
## 🧴 PR 요약
- 불필요한 override, required 이니셜라이저 삭제 후 convenience만 남겨두었습니다!

```swift
    convenience init(viewModel: StoreDetailViewModel) {
        self.init()
        self.viewModel = viewModel
        register(ProductTableViewCell.self,
                 forCellReuseIdentifier: ProductTableViewCell.reuseIdentifier)
        dataSource = self
    }
```

#### 📌 변경 사항
변경사항 및 주의 사항(모듈 설치 등)을 적어주세요.

##### 📸 ScreenShot
PR과 관련된 화면을 첨부해주세요.

##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #12 
