### PR TITLE
[Feat] #39 dynamic cell height 적용 위한 로직 추가

### DIFF
--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift
@@ -45,7 +45,7 @@ final class DetailReviewCell: UICollectionViewCell {
 
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 3
+        label.numberOfLines = 0
         label.textColor = Asset.Colors.gray5.color
         label.font = UIFont.font(style: .bodyMedium)
         return label
@@ -71,6 +71,7 @@ final class DetailReviewCell: UICollectionViewCell {
         writtenDateLabel.text = detailReview.writtenDate.toString()
         reviewImageView.image = UIImage(systemName: "zzz")
         descriptionLabel.text = detailReview.description
+        layoutIfNeeded()
     }
 
     private func layout() {

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewSection.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewSection.swift
@@ -17,7 +17,7 @@ extension StoreReviewViewController {
         case detailReviewCount
         case detailReviews
 
-        var cellHeight: CGFloat {
+        var estimatedCellHeight: CGFloat {
             switch self {
             case .moveToWriteReview:
                 return 40

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift
@@ -136,8 +136,17 @@ extension StoreReviewViewController: UICollectionViewDataSource {
 extension StoreReviewViewController: UICollectionViewDelegateFlowLayout {
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = collectionView.frame.width - 2 * Constraints.outerCollectionViewInset // inset 좌 우 각각 20
-        guard let height = Section(rawValue: indexPath.section)?.cellHeight else { return .zero }
+        let width = collectionView.frame.width - 2 * Constraints.outerCollectionViewInset
+        guard let height = Section(rawValue: indexPath.section)?.estimatedCellHeight else { return .zero }
+
+        if Section(rawValue: indexPath.section) == .detailReviews {
+            let dummyCellForCalculateheight = DetailReviewCell(frame: CGRect(origin: CGPoint(x: 0, y: 0),
+                                                      size: CGSize(width: width, height: height)))
+            dummyCellForCalculateheight.setUpContents(detailReview: detailReviewViewModel.detailReviews[indexPath.row])
+            let heightThatFits = dummyCellForCalculateheight.systemLayoutSizeFitting(CGSize(width: width, height: height)).height
+            return CGSize(width: width, height: heightThatFits)
+        }
+
         return CGSize(width: width, height: height)
     }
 

--- a/RefillStation/RefillStation/Resources/Assets+Generated.swift
+++ b/RefillStation/RefillStation/Resources/Assets+Generated.swift
@@ -8,6 +8,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -35,6 +38,16 @@ internal enum Asset {
     internal static let primary3 = ColorAsset(name: "Primary3")
   }
   internal enum Images {
+    internal enum MockData {
+      internal static let almaengShop = ImageAsset(name: "almaengShop")
+      internal static let arganShampoo = ImageAsset(name: "arganShampoo")
+      internal static let bodyWash = ImageAsset(name: "bodyWash")
+      internal static let earthShop = ImageAsset(name: "earthShop")
+      internal static let eco = ImageAsset(name: "eco")
+      internal static let purifyingShampoo = ImageAsset(name: "purifyingShampoo")
+      internal static let scrupShampoo = ImageAsset(name: "scrupShampoo")
+      internal static let youngGram = ImageAsset(name: "youngGram")
+    }
     internal static let iconArrowLeft = ImageAsset(name: "icon_arrow_left")
     internal static let iconArrowRightSmall = ImageAsset(name: "icon_arrow_right_small")
     internal static let iconBell = ImageAsset(name: "icon_bell")
@@ -82,6 +95,13 @@ internal final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -100,6 +120,16 @@ internal extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct ImageAsset {
   internal fileprivate(set) var name: String
@@ -137,6 +167,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -154,6 +191,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {


### PR DESCRIPTION
## 🧴 PR 요약
@anyukyung 
안녕하세요 클로이~
store review 화면에서 유저의 review가 길어지는 경우
dynamic한 cell 높이를 적용하는 로직을 제작하였습니다.

핵심적인 것을 요약하자면

![image](https://user-images.githubusercontent.com/67148595/208156487-6bd8dd6e-7f9e-49d2-9a17-9e66202d3347.png)

그림과 같이 UICollectionViewDelegateFlowLayout의 메서드인 
sizeForItemAt이 먼저 호출되고
그 뒤에 UICollectionViewDataSource의 메서드인 cellForItemAt이 호출됩니다.
sizeForItemAt에서 cell의 모든 contents가 반영되었을때의 높이를 계산해서 넣어주어야 하므로

```swift
let dummyCellForCalculateheight = DetailReviewCell(frame: CGRect(origin: CGPoint(x: 0, y: 0),
                                                   size: CGSize(width: width, height: height)))
dummyCellForCalculateheight.setUpContents(detailReview: detailReviewViewModel.detailReviews[indexPath.row])
let heightThatFits = dummyCellForCalculateheight.systemLayoutSizeFitting(CGSize(width: width, height: height)).height
return CGSize(width: width, height: heightThatFits)
```

위의 코드처럼 height를 구하기 위한 dummyCell에 
cell의 content들을 넣은뒤, 이 dummyCell의 systemLayoutSizeFitting(_:)를 적용한 height 값을
cell의 height로 넣어주면 content들로 인해 늘어난 cell의 height를 계산할 수 있습니다.

(이때 cell의 setUpContents() 메서드 내부에서 layoutIfNeeded() 메서드를 호출하여야 합니다.)

**P.S.**
swiftGen의 동작으로 인한 불필요한 커밋이 추가되었는데
해결법에 대한 논의를 별도로 진행해야할 것 같습니다.


##### 📸 ScreenShot
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-17 at 02 21 30](https://user-images.githubusercontent.com/67148595/208156357-42d4c262-5925-47e1-a2a7-88523e18a3a4.gif)

#### Linked Issue
close #39 
