### PR TITLE
[Feat] #41 더보기 버튼 추가 및 눌렀을때의 로직 제작

### DIFF
--- a/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -776,8 +776,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "173"
-            endingLineNumber = "173"
+            startingLineNumber = "169"
+            endingLineNumber = "169"
             landmarkName = "collectionView(_:layout:sizeForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -792,8 +792,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "186"
-            endingLineNumber = "186"
+            startingLineNumber = "182"
+            endingLineNumber = "182"
             landmarkName = "Constraints"
             landmarkType = "13">
          </BreakpointContent>
@@ -808,8 +808,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "184"
-            endingLineNumber = "184"
+            startingLineNumber = "180"
+            endingLineNumber = "180"
             landmarkName = "StoreReviewViewController"
             landmarkType = "21">
          </BreakpointContent>
@@ -824,8 +824,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "178"
-            endingLineNumber = "178"
+            startingLineNumber = "174"
+            endingLineNumber = "174"
             landmarkName = "collectionView(_:layout:insetForSectionAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -840,8 +840,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "102"
-            endingLineNumber = "102"
+            startingLineNumber = "100"
+            endingLineNumber = "100"
             landmarkName = "layout()"
             landmarkType = "7">
          </BreakpointContent>
@@ -856,8 +856,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "144"
-            endingLineNumber = "144"
+            startingLineNumber = "140"
+            endingLineNumber = "140"
             landmarkName = "collectionView(_:cellForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -872,8 +872,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "103"
-            endingLineNumber = "103"
+            startingLineNumber = "101"
+            endingLineNumber = "101"
             landmarkName = "layout()"
             landmarkType = "7">
          </BreakpointContent>
@@ -888,8 +888,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "170"
-            endingLineNumber = "170"
+            startingLineNumber = "166"
+            endingLineNumber = "166"
             landmarkName = "collectionView(_:layout:sizeForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -904,8 +904,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "161"
-            endingLineNumber = "161"
+            startingLineNumber = "157"
+            endingLineNumber = "157"
             landmarkName = "collectionView(_:layout:sizeForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -920,8 +920,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "162"
-            endingLineNumber = "162"
+            startingLineNumber = "158"
+            endingLineNumber = "158"
             landmarkName = "collectionView(_:layout:sizeForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -936,8 +936,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "159"
-            endingLineNumber = "159"
+            startingLineNumber = "155"
+            endingLineNumber = "155"
             landmarkName = "collectionView(_:layout:sizeForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -952,8 +952,8 @@
             filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "140"
-            endingLineNumber = "140"
+            startingLineNumber = "136"
+            endingLineNumber = "136"
             landmarkName = "collectionView(_:cellForItemAt:)"
             landmarkType = "7">
          </BreakpointContent>

--- a/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -734,5 +734,277 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "FACFF788-3C17-4E38-9C90-692964B6B085"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "31"
+            endingLineNumber = "31"
+            landmarkName = "setUpDetailReviewCollectionView()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "BB695290-B484-4C31-B383-0E585CB5A6A0"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "98"
+            endingLineNumber = "98"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "A86F3BF8-B638-43CE-B4CC-FB8C461E1494"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "173"
+            endingLineNumber = "173"
+            landmarkName = "collectionView(_:layout:sizeForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "DB7BBA89-2EA6-4F08-A525-A6E660B5D1E2"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "186"
+            endingLineNumber = "186"
+            landmarkName = "Constraints"
+            landmarkType = "13">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "52C52B8B-7317-4276-BC4E-8A072CA5F50D"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "184"
+            endingLineNumber = "184"
+            landmarkName = "StoreReviewViewController"
+            landmarkType = "21">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "D8D22239-FD3E-4FA3-BFEA-F63E1D2BFF07"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "178"
+            endingLineNumber = "178"
+            landmarkName = "collectionView(_:layout:insetForSectionAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "F2669896-B2B0-4636-ABEF-828A4F64627B"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "102"
+            endingLineNumber = "102"
+            landmarkName = "layout()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "CF068AB7-F95B-4CC7-91EA-F3C5A183D789"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "144"
+            endingLineNumber = "144"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "7CED236D-30B5-47A9-8486-C7521C794821"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "103"
+            endingLineNumber = "103"
+            landmarkName = "layout()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "1D87FF2F-4438-4465-9C2C-04F6C6477C90"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "170"
+            endingLineNumber = "170"
+            landmarkName = "collectionView(_:layout:sizeForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "172087D6-4583-4896-B2EF-C5FCD841CED0"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "161"
+            endingLineNumber = "161"
+            landmarkName = "collectionView(_:layout:sizeForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "0F7FCA05-9DAE-4D3F-B8DC-3722788B0093"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "162"
+            endingLineNumber = "162"
+            landmarkName = "collectionView(_:layout:sizeForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "59AF1A18-64A5-4A01-8EAA-0262A5389D3E"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "159"
+            endingLineNumber = "159"
+            landmarkName = "collectionView(_:layout:sizeForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "2FC0A210-438B-4D46-9B4F-79B585C274A0"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "140"
+            endingLineNumber = "140"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "83805C3B-60B9-456B-B683-FE29D9C0D193"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "90"
+            endingLineNumber = "90"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "4CCBAA0E-3D0F-492E-9FE9-518FA4E0091C"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "129"
+            endingLineNumber = "129"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "E29E9371-2AD1-4A19-B99E-30C80D435CC4"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "134"
+            endingLineNumber = "134"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift
@@ -72,8 +72,6 @@ final class DetailReviewCell: UICollectionViewCell {
 
     @objc
     private func seeMoreButtonTapped(_ sender: UIButton) {
-        layoutSubviews()
-        layoutIfNeeded()
         reloadCell?()
     }
 

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/DetailReviewCell.swift
@@ -45,11 +45,21 @@ final class DetailReviewCell: UICollectionViewCell {
 
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 0
+        label.numberOfLines = 3
         label.textColor = Asset.Colors.gray5.color
         label.font = UIFont.font(style: .bodyMedium)
         return label
     }()
+
+    private lazy var seeMoreButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("더보기", for: .normal)
+        button.setTitleColor(UIColor.blue, for: .normal)
+        button.addTarget(self, action: #selector(seeMoreButtonTapped(_:)), for: .touchUpInside)
+        return button
+    }()
+
+    var reloadCell: (() -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -58,6 +68,17 @@ final class DetailReviewCell: UICollectionViewCell {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    @objc
+    private func seeMoreButtonTapped(_ sender: UIButton) {
+        layoutSubviews()
+        layoutIfNeeded()
+        reloadCell?()
+    }
+
+    func setUpSeeMore(isSeeMoreButtonAlreadyTapped: Bool) {
+        descriptionLabel.numberOfLines = isSeeMoreButtonAlreadyTapped ? 0 : 3
     }
 
     func setUpImages(userImage: UIImage, reviewImage: UIImage) {
@@ -75,7 +96,7 @@ final class DetailReviewCell: UICollectionViewCell {
     }
 
     private func layout() {
-        [profileImageView, userNameLabel, writtenDateLabel, reviewImageView, descriptionLabel].forEach {
+        [profileImageView, userNameLabel, writtenDateLabel, reviewImageView, descriptionLabel, seeMoreButton].forEach {
             contentView.addSubview($0)
         }
 
@@ -108,8 +129,13 @@ final class DetailReviewCell: UICollectionViewCell {
         }
 
         descriptionLabel.snp.makeConstraints { description in
-            description.leading.trailing.bottom.equalToSuperview()
+            description.leading.trailing.equalToSuperview()
             description.top.equalTo(reviewImageView.snp.bottom).offset(10)
+        }
+
+        seeMoreButton.snp.makeConstraints { button in
+            button.top.equalTo(descriptionLabel.snp.bottom)
+            button.trailing.bottom.equalToSuperview()
         }
     }
 }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift
@@ -120,6 +120,26 @@ extension StoreReviewViewController: UICollectionViewDataSource {
                 withReuseIdentifier: DetailReviewCell.reuseIdentifier,
                 for: indexPath) as? DetailReviewCell else { return UICollectionViewCell() }
             cell.setUpContents(detailReview: detailReviewViewModel.detailReviews[indexPath.row])
+
+            cell.setUpSeeMore(
+                isSeeMoreButtonAlreadyTapped: detailReviewViewModel.seeMoreTappedIndexPaths.contains(indexPath)
+            )
+
+            cell.reloadCell = {
+                if self.detailReviewViewModel.seeMoreTappedIndexPaths.contains(indexPath) {
+                    self.detailReviewViewModel.seeMoreTappedIndexPaths.remove(
+                        at: self.detailReviewViewModel.seeMoreTappedIndexPaths.firstIndex(of: indexPath)!
+                    )
+                } else {
+                    self.detailReviewViewModel.seeMoreTappedIndexPaths.append(indexPath)
+                }
+
+                cell.setUpSeeMore(
+                    isSeeMoreButtonAlreadyTapped: self.detailReviewViewModel.seeMoreTappedIndexPaths.contains(indexPath)
+                )
+                self.detailReviewCollectionView.reloadItems(at: [indexPath])
+            }
+
             return cell
         default:
             guard let reuseIdentifier = Section(rawValue: indexPath.section)?.reuseIdentifier else {
@@ -143,6 +163,9 @@ extension StoreReviewViewController: UICollectionViewDelegateFlowLayout {
             let dummyCellForCalculateheight = DetailReviewCell(frame: CGRect(origin: CGPoint(x: 0, y: 0),
                                                       size: CGSize(width: width, height: height)))
             dummyCellForCalculateheight.setUpContents(detailReview: detailReviewViewModel.detailReviews[indexPath.row])
+            dummyCellForCalculateheight.setUpSeeMore(
+                isSeeMoreButtonAlreadyTapped: self.detailReviewViewModel.seeMoreTappedIndexPaths.contains(indexPath)
+            )
             let heightThatFits = dummyCellForCalculateheight.systemLayoutSizeFitting(CGSize(width: width, height: height)).height
             return CGSize(width: width, height: heightThatFits)
         }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/StoreReviewViewController.swift
@@ -133,10 +133,6 @@ extension StoreReviewViewController: UICollectionViewDataSource {
                 } else {
                     self.detailReviewViewModel.seeMoreTappedIndexPaths.append(indexPath)
                 }
-
-                cell.setUpSeeMore(
-                    isSeeMoreButtonAlreadyTapped: self.detailReviewViewModel.seeMoreTappedIndexPaths.contains(indexPath)
-                )
                 self.detailReviewCollectionView.reloadItems(at: [indexPath])
             }
 

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/ViewModel/DetailReviewViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/StoreReview/ViewModel/DetailReviewViewModel.swift
@@ -10,4 +10,5 @@ import Foundation
 final class DetailReviewViewModel {
 
     var detailReviews = [DetailReview]()
+    var seeMoreTappedIndexPaths = [IndexPath]()
 }


### PR DESCRIPTION
## 🧴 PR 요약
@anyukyung 
안녕하세요 클로이~
이번엔 더보기 버튼을 눌렀을때 cell이 늘어났다가
다시 더보기 버튼을 누르면 cell이 줄어드는 로직을 제작했습니다.

로직에 대해 간단히 설명하자면

cell 내부의 더보기 버튼이 눌리면 reloadCell이라는 클로저가 실행되는데,

이 클로저는 이번에 더보기 버튼을 누른 cell의 indexPath가
viewModel의 seeMoreTappedIndexPaths 배열에 있는지 검사한 뒤
있다면 삭제를, 없다면 추가를 해주고
해당 cell만 reload하는 역할을 합니다.

cellForItemAt에서 cell의 indexPath가 viewModel의 seeMoreTappedIndexPaths 배열에
존재하는지를 확인하고, 존재한다면 numberOfLines를 0으로 (더보기 버튼이 눌린 상태)
그렇지 않다면 numberOfLines를 3으로 설정해주었습니다.

sizeForItemAt에서도 위와 같은 로직을 적용하여 높이 계산을 진행해주었습니다.

## 📸 ScreenShot
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-17 at 05 05 39](https://user-images.githubusercontent.com/67148595/208182104-ddb1f171-be24-4023-b8d3-612c5638927f.gif)


#### Linked Issue
close #41
