### PR TITLE
Feature/#98 버그 수정 및 리팩토링

### DIFF
--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/ProductList/ProductCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/ProductList/ProductCell.swift
@@ -8,16 +8,8 @@
 import UIKit
 
 final class ProductCell: UICollectionViewCell {
-    static let reuseIdentifier = "productCell"
+    static let reuseIdentifier = String(describing: ProductCell.self)
 
-    private var productImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.backgroundColor = Asset.Colors.gray1.color
-        imageView.layer.cornerRadius = 4
-        imageView.contentMode = .scaleAspectFill
-        imageView.clipsToBounds = true
-        return imageView
-    }()
     private var brandLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.font(style: .captionLarge)
@@ -30,21 +22,6 @@ final class ProductCell: UICollectionViewCell {
         label.textColor = Asset.Colors.gray7.color
         return label
     }()
-
-    private var priceLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.font(style: .buttonLarge)
-        label.textColor = Asset.Colors.primary8.color
-        return label
-    }()
-
-    private var pricePerGramLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.font(style: .buttonLarge)
-        label.textColor = Asset.Colors.gray7.color
-        return label
-    }()
-
     private let divisionLine: UIView = {
         let line = UIView(frame: .zero)
         line.backgroundColor = Asset.Colors.gray1.color
@@ -60,45 +37,26 @@ final class ProductCell: UICollectionViewCell {
         super.init(coder: coder)
     }
 
-    func setUpImage(image: UIImage) {
-        productImageView.image = image
-    }
-
     func setUpContents(product: Product) {
         brandLabel.text = product.brand
         productNameLabel.text = product.name
-        priceLabel.text = "\(product.price)원"
-        pricePerGramLabel.text = "/\(product.measurement)"
     }
 
     private func layout() {
-        [productImageView, brandLabel, productNameLabel, priceLabel, pricePerGramLabel, divisionLine].forEach {
+        [brandLabel, productNameLabel, divisionLine].forEach {
             contentView.addSubview($0)
-        }
-        productImageView.snp.makeConstraints {
-            $0.width.height.equalTo(80)
-            $0.top.equalToSuperview().inset(16)
         }
         brandLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
-            $0.leading.equalTo(productImageView.snp.trailing).offset(12)
+            $0.leading.equalToSuperview()
         }
         productNameLabel.snp.makeConstraints {
             $0.top.equalTo(brandLabel.snp.bottom).offset(5)
             $0.leading.equalTo(brandLabel)
         }
-        priceLabel.snp.makeConstraints {
-            $0.top.equalTo(productNameLabel.snp.bottom).offset(7)
-            $0.leading.equalTo(productNameLabel)
-        }
-
-        pricePerGramLabel.snp.makeConstraints {
-            $0.top.equalTo(productNameLabel.snp.bottom).offset(7)
-            $0.leading.equalTo(priceLabel.snp.trailing)
-        }
 
         divisionLine.snp.makeConstraints {
-            $0.top.equalTo(productImageView.snp.bottom).offset(16)
+            $0.top.equalTo(productNameLabel.snp.bottom).offset(16)
             $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(1)
         }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailPhotoReviewViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailPhotoReviewViewController.swift
@@ -104,11 +104,13 @@ final class DetailPhotoReviewViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        navigationController?.navigationBar.isHidden = true
+        navigationController?.setNavigationBarHidden(true, animated: true)
+        tabBarController?.tabBar.isHidden = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        navigationController?.navigationBar.isHidden = false
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        tabBarController?.tabBar.isHidden = false
     }
 
     private func bind() {

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
@@ -14,13 +14,7 @@ final class DetailReviewCell: UICollectionViewCell {
     // MARK: - Private Properties
     private var review: Review?
     private var tags: [Tag]?
-    private var tagCollectionViewHeight: CGFloat = 40 {
-        didSet {
-            tagCollectionView.snp.remakeConstraints {
-                $0.height.equalTo(tagCollectionViewHeight)
-            }
-        }
-    }
+    private var tagCollectionViewHeight: CGFloat = 40
 
     // MARK: - Event Handling
     var photoImageTapped: (() -> Void)?
@@ -52,9 +46,20 @@ final class DetailReviewCell: UICollectionViewCell {
         return label
     }()
 
+    private lazy var reportButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("신고", for: .normal)
+        button.titleLabel?.font = .font(style: .captionLarge)
+        button.setTitleColor(Asset.Colors.gray5.color, for: .normal)
+        button.addAction(UIAction { [weak self] _ in
+            self?.reportButtonTapped?()
+        }, for: .touchUpInside)
+        return button
+    }()
+
     private lazy var reviewInfoView: UIView = {
         let reviewInfoView = UIView()
-        [profileImageView, userNameLabel, writtenDateLabel].forEach { reviewInfoView.addSubview($0) }
+        [profileImageView, userNameLabel, writtenDateLabel, reportButton].forEach { reviewInfoView.addSubview($0) }
         profileImageView.snp.makeConstraints { profile in
             profile.leading.equalToSuperview()
             profile.top.bottom.equalToSuperview()
@@ -72,6 +77,11 @@ final class DetailReviewCell: UICollectionViewCell {
             dateLabel.top.equalTo(userNameLabel.snp.bottom).offset(5)
             dateLabel.bottom.equalToSuperview().inset(5)
         }
+
+        reportButton.snp.makeConstraints {
+            $0.trailing.top.equalToSuperview()
+        }
+        reportButton.setContentHuggingPriority(.required, for: .vertical)
         return reviewInfoView
     }()
 
@@ -153,17 +163,6 @@ final class DetailReviewCell: UICollectionViewCell {
         stackView.spacing = 14
         stackView.distribution = .fill
         return stackView
-    }()
-
-    private lazy var reportButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("신고", for: .normal)
-        button.titleLabel?.font = .font(style: .captionLarge)
-        button.setTitleColor(Asset.Colors.gray5.color, for: .normal)
-        button.addAction(UIAction { [weak self] _ in
-            self?.reportButtonTapped?()
-        }, for: .touchUpInside)
-        return button
     }()
 
     override init(frame: CGRect) {

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
@@ -23,14 +23,9 @@ final class DetailReviewCell: UICollectionViewCell {
     }
 
     // MARK: - Event Handling
-    override var isSelected: Bool {
-        didSet {
-            descriptionLabel.numberOfLines = isSelected ? 0 : 3
-            layoutIfNeeded()
-        }
-    }
     var photoImageTapped: (() -> Void)?
     var reportButtonTapped: (() -> Void)?
+    var seeMoreTapped: (() -> Void)?
 
     // MARK: - UI Components
     private let profileImageView: UIImageView = {
@@ -120,12 +115,16 @@ final class DetailReviewCell: UICollectionViewCell {
         return reviewImageOuterView
     }()
 
-    private let descriptionLabel: UILabel = {
+    private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 3
         label.textColor = Asset.Colors.gray5.color
         label.font = UIFont.font(style: .bodyMedium)
         label.lineBreakStrategy = .hangulWordPriority
+        label.isUserInteractionEnabled = true
+        let tapGesture = UITapGestureRecognizer(target: self,
+                                                action: #selector(descriptionLabelTapped(_:)))
+        label.addGestureRecognizer(tapGesture)
         return label
     }()
 
@@ -176,7 +175,7 @@ final class DetailReviewCell: UICollectionViewCell {
         super.init(coder: coder)
     }
 
-    func setUpContents(review: Review) {
+    func setUpContents(review: Review, shouldSeeMore: Bool) {
         self.review = review
         self.tags = review.tags.filter { $0 != .noKeywordToChoose }
         tagCollectionView.reloadData()
@@ -193,6 +192,8 @@ final class DetailReviewCell: UICollectionViewCell {
                 $0.height.equalTo(self.tagCollectionView.contentSize.height)
             }
         }
+
+        descriptionLabel.numberOfLines = shouldSeeMore ? 0 : 3
     }
 
     private func layout() {
@@ -244,6 +245,11 @@ final class DetailReviewCell: UICollectionViewCell {
     @objc
     private func imageViewDidTapped(_ sender: UITapGestureRecognizer) {
         photoImageTapped?()
+    }
+
+    @objc
+    private func descriptionLabelTapped(_ sender: UITapGestureRecognizer) {
+        seeMoreTapped?()
     }
 }
 

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
@@ -293,12 +293,13 @@ fileprivate extension Date {
     func toString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR") ?? .current
         if let currentYear = Calendar.current.dateComponents([.year], from: Date()).year,
            let dateYear = Calendar.current.dateComponents([.year], from: Date()).year,
            currentYear == dateYear {
-            dateFormatter.dateFormat = "MM.dd.EE"
+            dateFormatter.dateFormat = "M.d.EE"
         } else {
-            dateFormatter.dateFormat = "yyyy.MM.dd"
+            dateFormatter.dateFormat = "yyyy.M.d"
         }
 
         return dateFormatter.string(from: self)

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
@@ -177,23 +177,26 @@ final class DetailReviewCell: UICollectionViewCell {
 
     func setUpContents(review: Review, shouldSeeMore: Bool) {
         self.review = review
-        self.tags = review.tags.filter { $0 != .noKeywordToChoose }
-        tagCollectionView.reloadData()
-        tagCollectionView.layoutIfNeeded()
+        setUpTagCollectionViewContents()
         userNameLabel.text = review.userNickname
         writtenDateLabel.text = review.writtenDate.toString()
         descriptionLabel.text = review.description
         imageCountLabel.text = "1 / \(review.imageURL.count)"
         imageCountLabel.isHidden = review.imageURL.count <= 1
-        // TODO: Fetch Image(profile, review) with URL
         addArrangedSubviewsToOuterStackview()
+        descriptionLabel.numberOfLines = shouldSeeMore ? 0 : 3
+    }
+
+    private func setUpTagCollectionViewContents() {
+        guard let review = review else { return }
+        tags = review.tags.filter { $0 != .noKeywordToChoose }
+        tagCollectionView.reloadData()
+        tagCollectionView.layoutIfNeeded()
         DispatchQueue.main.async {
             self.tagCollectionView.snp.remakeConstraints {
                 $0.height.equalTo(self.tagCollectionView.contentSize.height)
             }
         }
-
-        descriptionLabel.numberOfLines = shouldSeeMore ? 0 : 3
     }
 
     private func layout() {

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailSection.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailSection.swift
@@ -132,4 +132,31 @@ extension StoreDetailViewController {
             }
         }
     }
+
+    func section(mode: StoreDetailViewModel.TabBarMode, sectionIndex: Int) -> StoreDetailSection {
+        if sectionIndex == StoreDetailSection.storeDetailInfo.sectionIndex {
+            return StoreDetailSection.storeDetailInfo
+        } else if sectionIndex == StoreDetailSection.tabBar.sectionIndex {
+            return StoreDetailSection.tabBar
+        }
+
+        switch (mode, sectionIndex) {
+        case (.productLists, 2):
+            return StoreDetailSection.productCategory
+        case (.productLists, 3):
+            return StoreDetailSection.filteredProductsCount
+        case (.productLists, 4):
+            return StoreDetailSection.productList
+        case (.reviews, 2):
+            return StoreDetailSection.reviewOverview
+        case (.reviews, 3):
+            return StoreDetailSection.review
+        case (.operationInfo, 2):
+            return StoreDetailSection.operationNotice
+        case (.operationInfo, 3):
+            return StoreDetailSection.operationInfo
+        default:
+            return .storeDetailInfo
+        }
+    }
 }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -227,9 +227,14 @@ extension StoreDetailViewController {
                 }
 
                 if let cell = cell as? DetailReviewCell, case let .review(review) = itemIdentifier {
-                    cell.setUpContents(review: review)
+                    let shouldSeeMore = self.viewModel.reviewSeeMoreIndexPaths.contains(indexPath)
+                    cell.setUpContents(review: review, shouldSeeMore: shouldSeeMore)
                     cell.photoImageTapped = { [weak self] in
                         self?.coordinator?.showDetailPhotoReview(photoURLs: review.imageURL)
+                    }
+                    cell.seeMoreTapped = {
+                        self.viewModel.reviewSeeMoreTapped(indexPath: indexPath)
+                        self.reloadCellAt(indexPath: indexPath)
                     }
                     cell.reportButtonTapped = { [weak self] in
                         let reportPopUp = ReviewReportPopUpViewController(
@@ -282,18 +287,6 @@ extension StoreDetailViewController {
 
 // MARK: - UICollectionViewDelegate
 extension StoreDetailViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if section(mode: viewModel.mode, sectionIndex: indexPath.section) != .operationInfo {
-            reloadCellAt(indexPath: indexPath)
-        }
-    }
-
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        if section(mode: viewModel.mode, sectionIndex: indexPath.section) != .operationInfo {
-            reloadCellAt(indexPath: indexPath)
-        }
-    }
-
     private func reloadCellAt(indexPath: IndexPath) {
         if let item = storeDetailDataSource.itemIdentifier(for: indexPath) {
             var currentSnapshot = storeDetailDataSource.snapshot()

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -296,7 +296,7 @@ extension StoreDetailViewController {
 
 // MARK: - Cell Registration
 extension StoreDetailViewController {
-    func storeDetailInfoCellRegisration() -> UICollectionView.CellRegistration<StoreDetailInfoViewCell, StoreDetailItem> {
+    private func storeDetailInfoCellRegisration() -> UICollectionView.CellRegistration<StoreDetailInfoViewCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<StoreDetailInfoViewCell, StoreDetailItem> { cell, indexPath, item in
             guard case let .storeDetailInfo(store) = item else { return }
             cell.setUpContents(store: store)
@@ -304,7 +304,7 @@ extension StoreDetailViewController {
         }
     }
 
-    func tabBarCellRegistration() -> UICollectionView.CellRegistration<StoreDetailTabBarCell, StoreDetailItem> {
+    private func tabBarCellRegistration() -> UICollectionView.CellRegistration<StoreDetailTabBarCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<StoreDetailTabBarCell, StoreDetailItem> { cell, indexPath, item in
             cell.headerTapped = { [weak self] mode in
                 if self?.viewModel.mode != mode {
@@ -316,7 +316,7 @@ extension StoreDetailViewController {
         }
     }
 
-    func productCategoriesCellRegistration() -> UICollectionView.CellRegistration<ProductCategoriesCell, StoreDetailItem> {
+    private func productCategoriesCellRegistration() -> UICollectionView.CellRegistration<ProductCategoriesCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<ProductCategoriesCell, StoreDetailItem> { cell, indexPath, item in
             cell.setUpContents(info: .init(categories: self.viewModel.categories,
                                            currentFilter: self.viewModel.currentCategoryFilter))
@@ -327,21 +327,21 @@ extension StoreDetailViewController {
         }
     }
 
-    func filteredCellRegistration() -> UICollectionView.CellRegistration<FilteredProductCountCell, StoreDetailItem> {
+    private func filteredCellRegistration() -> UICollectionView.CellRegistration<FilteredProductCountCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<FilteredProductCountCell, StoreDetailItem> { cell, indexPath, item in
             guard case let .filteredProduct(count) = item else { return }
             cell.setUpContents(filteredCount: count)
         }
     }
 
-    func productCellRegistration() -> UICollectionView.CellRegistration<ProductCell, StoreDetailItem> {
+    private func productCellRegistration() -> UICollectionView.CellRegistration<ProductCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<ProductCell, StoreDetailItem> { cell, indexPath, item in
             guard case let .productList(product) = item else { return }
             cell.setUpContents(product: product)
         }
     }
 
-    func reviewInfoCellRegistration() -> UICollectionView.CellRegistration<ReviewInfoCell, StoreDetailItem> {
+    private func reviewInfoCellRegistration() -> UICollectionView.CellRegistration<ReviewInfoCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<ReviewInfoCell, StoreDetailItem> { cell, indexPath, item in
             guard case let .reviewOverview(rankTags) = item else { return }
             cell.moveToRegisterReview = { [weak self] in
@@ -352,7 +352,7 @@ extension StoreDetailViewController {
         }
     }
 
-    func detailReviewCellRegistration() -> UICollectionView.CellRegistration<DetailReviewCell, StoreDetailItem> {
+    private func detailReviewCellRegistration() -> UICollectionView.CellRegistration<DetailReviewCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<DetailReviewCell, StoreDetailItem> { cell, indexPath, item in
             guard case let .review(review) = item else { return }
             let shouldSeeMore = self.viewModel.reviewSeeMoreIndexPaths.contains(indexPath)
@@ -380,11 +380,11 @@ extension StoreDetailViewController {
         }
     }
 
-    func operationNoticeCellRegistration() -> UICollectionView.CellRegistration<OperationNoticeCell, StoreDetailItem> {
+    private func operationNoticeCellRegistration() -> UICollectionView.CellRegistration<OperationNoticeCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<OperationNoticeCell, StoreDetailItem> { cell, indexPath, item in
         }
     }
-    func operationInfoCellRegistration() -> UICollectionView.CellRegistration<OperationInfoCell, StoreDetailItem> {
+    private func operationInfoCellRegistration() -> UICollectionView.CellRegistration<OperationInfoCell, StoreDetailItem> {
         return UICollectionView.CellRegistration<OperationInfoCell, StoreDetailItem> { cell, indexPath, item in
             guard case let .operationInfo(operationInfo) = item else { return }
             let shouldShowMore = self.viewModel.operationInfoSeeMoreIndexPaths.contains(indexPath)

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -89,9 +89,6 @@ final class StoreDetailViewController: UIViewController {
     }
 
     private func setUpCollectionView() {
-        StoreDetailSection.allCases.forEach {
-            collectionView.register($0.cell, forCellWithReuseIdentifier: $0.reuseIdentifier)
-        }
         collectionView.dataSource = storeDetailDataSource
         collectionView.delegate = self
         collectionView.allowsMultipleSelection = true

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -365,12 +365,12 @@ extension StoreDetailViewController {
                 let reportPopUp = ReviewReportPopUpViewController(
                     viewModel: ReviewReportPopUpViewModel(reportedUserId: review.userId)
                 ) {
-                    let reportedPopUp = PumpPopUpViewController(title: nil,
+                    let reportCompletePopUp = PumpPopUpViewController(title: nil,
                                                                 description: "해당 댓글이 신고처리 되었습니다.")
-                    reportedPopUp.addAction(title: "확인", style: .basic) {
+                    reportCompletePopUp.addAction(title: "확인", style: .basic) {
                         self?.dismiss(animated: true)
                     }
-                    self?.present(reportedPopUp, animated: true)
+                    self?.present(reportCompletePopUp, animated: true)
                 }
                 self?.present(reportPopUp, animated: true)
             }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewModel/StoreDetailViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewModel/StoreDetailViewModel.swift
@@ -39,6 +39,7 @@ final class StoreDetailViewModel {
     var reviews = [Review]()
     var totalTagVoteCount = 0
     var rankTags = [RankTag]()
+    var reviewSeeMoreIndexPaths = Set<IndexPath>()
 
     // MARK: - Operation Info
     lazy var operationInfos: [OperationInfo] = {
@@ -104,6 +105,14 @@ final class StoreDetailViewModel {
     func categoryButtonDidTapped(category: ProductCategory?) {
         guard let category = category else { return }
         currentCategoryFilter = category
+    }
+
+    func reviewSeeMoreTapped(indexPath: IndexPath) {
+        if reviewSeeMoreIndexPaths.contains(indexPath) {
+            reviewSeeMoreIndexPaths.remove(indexPath)
+        } else {
+            reviewSeeMoreIndexPaths.insert(indexPath)
+        }
     }
 
     func operationInfoSeeMoreTapped(indexPath: IndexPath) {


### PR DESCRIPTION
안녕하세요 클로이~ @anyukyung 
StoreDetail 화면에서 발생하던 버그 수정과 Cell Registration을 통한 리팩토링이 이루어졌습니다~
## 🧴 PR 요약
- 긴 내용을 담고 있는 리뷰가 아님에도 셀 선택시 화면이 움직이는 문제 해결
- 사진 자세히 보기 화면에서 하단에 탭바가 노출되는 문제 해결
- 리뷰 작성 날짜가 영어로 노출되는 문제 해결
- 상품 사진, 가격 제거
- Cell Registration으로 리팩토링
  - Cell Registration을 StoreDetailSection (enum) 의 변수로 만들어 가지고 있어보려 했지만 방법을 찾지 못했습니다 ㅠ..
  - feature/98-cellReg간략화 브랜치에 간략화 시도가 담겨져있으나 Cell의 type 자체를 CellRegistration할때 등록해주지 않으면 (해당 브랜치처럼 UICollectionViewCell로 등록해버리면) Cell의 Type down casting이 실패할 수 밖에 없는 구조였습니다.
- Layout 관련 콘솔 에러도 해결해보려 했으나 마땅한 해결책을 찾지 못했습니다 ㅠ

```swift
        let storeDetailInfoCellRegisration = storeDetailInfoCellRegisration()
        let tabBarCellRegistration = tabBarCellRegistration()
        let productCategoriesCellRegistration = productCategoriesCellRegistration()
        let filteredCellRegistration = filteredCellRegistration()
        let productCellRegistration = productCellRegistration()
        let reviewInfoCellRegistration = reviewInfoCellRegistration()
        let detailReviewCellRegistration = detailReviewCellRegistration()
        let operationNoticeCellRegistration = operationNoticeCellRegistration()
        let operationInfoCellRegistration = operationInfoCellRegistration()
```
위처럼 변수를 따로 빼놓은 이유는 
<img width="996" alt="image" src="https://user-images.githubusercontent.com/67148595/215969065-220abf89-4209-487e-bea5-2cfe157f0cbe.png">
공식문서에서 위와 같이 설명하고 있기 때문입니다. (cell provider closure 내에서 registration 생성하지 말 것)
#### Linked Issue
close #98 
