### PR TITLE
Feature/#121 추천수 가져오기 기능 제작, URLRequest 생성파트 리팩토링

### DIFF
--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3210B52D298F88410034CBA7 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52C298F88410034CBA7 /* HTTPMethod.swift */; };
 		3210B52F298F94ED0034CBA7 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52E298F94ED0034CBA7 /* NetworkResult.swift */; };
 		3210B531298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */; };
+		3210B535298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */; };
 		322E15E4297A0B3600FE2E2F /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */; };
 		322E15E6297A0B6600FE2E2F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */; };
 		322E15E8297A0CD700FE2E2F /* RegisterReviewDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */; };
@@ -171,6 +172,7 @@
 		3210B52C298F88410034CBA7 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		3210B52E298F94ED0034CBA7 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendUseCase.swift; sourceTree = "<group>"; };
+		3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendDTO.swift; sourceTree = "<group>"; };
 		322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
 		322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterReviewDIContainer.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 				32E6AE37298E5629005AA542 /* StoreDTO.swift */,
 				32E6AE43298E7EF4005AA542 /* ProductDTO.swift */,
 				32E6AE3B298E7C67005AA542 /* StoreRecommendDTO.swift */,
+				3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */,
 				32E6AE45298E80CD005AA542 /* ReviewDTO.swift */,
 			);
 			path = Store;
@@ -1228,6 +1231,7 @@
 				325985E9294C527000D26A37 /* DIContainer.swift in Sources */,
 				324CCBE029321616001F6FDA /* DetailReviewCell.swift in Sources */,
 				32DFDAE12976BAE400B6EDA3 /* FilteredProductCountCell.swift in Sources */,
+				3210B535298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift in Sources */,
 				322E15EA297A0CE100FE2E2F /* RegisterReviewCoordinator.swift in Sources */,
 				FC60D8372962C36F00C676A6 /* DefaultTagReviewViewModel.swift in Sources */,
 				FCD9721A298C462900E27792 /* LocationPermissionViewController.swift in Sources */,

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3210B52B298F834B0034CBA7 /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52A298F834B0034CBA7 /* RepositoryError.swift */; };
 		3210B52D298F88410034CBA7 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52C298F88410034CBA7 /* HTTPMethod.swift */; };
 		3210B52F298F94ED0034CBA7 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52E298F94ED0034CBA7 /* NetworkResult.swift */; };
+		3210B531298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */; };
 		322E15E4297A0B3600FE2E2F /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */; };
 		322E15E6297A0B6600FE2E2F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */; };
 		322E15E8297A0CD700FE2E2F /* RegisterReviewDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */; };
@@ -169,6 +170,7 @@
 		3210B52A298F834B0034CBA7 /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
 		3210B52C298F88410034CBA7 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		3210B52E298F94ED0034CBA7 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendUseCase.swift; sourceTree = "<group>"; };
 		322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
 		322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterReviewDIContainer.swift; sourceTree = "<group>"; };
@@ -614,6 +616,7 @@
 				FCE00A70294C916600B5C05F /* FetchStoresUseCase.swift */,
 				FCE00A74294C917B00B5C05F /* FetchProductsUseCase.swift */,
 				FCE00A78294C919A00B5C05F /* FetchStoreReviewsUseCase.swift */,
+				3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */,
 				FCE00A7A294C91A200B5C05F /* RecommendStoreUseCase.swift */,
 			);
 			path = Store;
@@ -1219,6 +1222,7 @@
 				FC3EBDF32932872100A9C1F9 /* Product.swift in Sources */,
 				FC90448E29671FC900B43BB9 /* LevelCollectionViewCell.swift in Sources */,
 				FCE00A7B294C91A200B5C05F /* RecommendStoreUseCase.swift in Sources */,
+				3210B531298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift in Sources */,
 				32A0F4FF2981754B00A04ECC /* AccountRepositoryInterface.swift in Sources */,
 				32C22965297D35BA0019EAF6 /* PumpPopUpViewController.swift in Sources */,
 				325985E9294C527000D26A37 /* DIContainer.swift in Sources */,

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3210B52F298F94ED0034CBA7 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52E298F94ED0034CBA7 /* NetworkResult.swift */; };
 		3210B531298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */; };
 		3210B535298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */; };
+		322982EE29907CC20081B288 /* URLComponentsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322982ED29907CC20081B288 /* URLComponentsExtension.swift */; };
 		322E15E4297A0B3600FE2E2F /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */; };
 		322E15E6297A0B6600FE2E2F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */; };
 		322E15E8297A0CD700FE2E2F /* RegisterReviewDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */; };
@@ -173,6 +174,7 @@
 		3210B52E298F94ED0034CBA7 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendUseCase.swift; sourceTree = "<group>"; };
 		3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendDTO.swift; sourceTree = "<group>"; };
+		322982ED29907CC20081B288 /* URLComponentsExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponentsExtension.swift; sourceTree = "<group>"; };
 		322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
 		322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterReviewDIContainer.swift; sourceTree = "<group>"; };
@@ -940,6 +942,7 @@
 			isa = PBXGroup;
 			children = (
 				FCE00A9E29517E5600B5C05F /* Network */,
+				322982ED29907CC20081B288 /* URLComponentsExtension.swift */,
 			);
 			path = Infrastructure;
 			sourceTree = "<group>";
@@ -1267,6 +1270,7 @@
 				FCE00A96294C966C00B5C05F /* RegisterReviewRepositoryInterface.swift in Sources */,
 				32DB626E2981689C008C2522 /* WithdrawUseCase.swift in Sources */,
 				FC84FAC9293B640300428AAA /* RequestRegionViewController.swift in Sources */,
+				322982EE29907CC20081B288 /* URLComponentsExtension.swift in Sources */,
 				32A0F4F12981707100A04ECC /* SignOutUseCase.swift in Sources */,
 				322E15E8297A0CD700FE2E2F /* RegisterReviewDIContainer.swift in Sources */,
 				32DFDAE32976C93500B6EDA3 /* DetailPhotoReviewViewController.swift in Sources */,

--- a/RefillStation/RefillStation/Data/DTOs/Store/FetchStoreRecommendDTO.swift
+++ b/RefillStation/RefillStation/Data/DTOs/Store/FetchStoreRecommendDTO.swift
@@ -1,0 +1,26 @@
+//
+//  FetchStoreRecommendDTO.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2023/02/05.
+//
+
+import Foundation
+
+struct FetchStoreRecommendDTO: Decodable {
+    let recommendation: Bool?
+    let count: Int?
+}
+
+struct FetchStoreRecommendRequestDTO: Encodable {
+    let storeId: Int
+}
+
+extension FetchStoreRecommendDTO {
+    func toResponseValue() -> FetchStoreRecommendResponseValue {
+        return FetchStoreRecommendResponseValue(
+            recommendCount: count ?? 0,
+            didRecommended: recommendation ?? false
+        )
+    }
+}

--- a/RefillStation/RefillStation/Data/DTOs/Store/StoreDTO.swift
+++ b/RefillStation/RefillStation/Data/DTOs/Store/StoreDTO.swift
@@ -36,37 +36,7 @@ struct StoreDTO: Decodable {
     }
 }
 
-struct StoreFetchResult {
-    let storeId: Int
-    let name: String
-    let address: String
-    let distance: Double
-    let phoneNumber: String
-    let snsAddress: String
-    let imageURL: [String]
-    let businessHour: [BusinessHour]
-    let notice: String
-}
-
 extension StoreDTO {
-    func toFetchResult() -> StoreFetchResult {
-        return StoreFetchResult(
-            storeId: id ?? 0,
-            name: name ?? "",
-            address: address ?? "",
-            distance: Double(distance ?? "") ?? 0,
-            phoneNumber: callNumber ?? "",
-            snsAddress: instaAccount ?? "",
-            imageURL: imgStores.compactMap { $0.path },
-            businessHour: businessHour?.map { dto in
-                BusinessHour(day: .allCases.first(where: {
-                    $0.name == dto.day
-                }) ?? .mon, time: dto.time)
-            } ?? [],
-            notice: notice ?? ""
-        )
-    }
-
     func toDomain() -> Store {
         return Store(
             storeId: id ?? 0,

--- a/RefillStation/RefillStation/Data/DTOs/Store/StoreRecommendDTO.swift
+++ b/RefillStation/RefillStation/Data/DTOs/Store/StoreRecommendDTO.swift
@@ -12,23 +12,11 @@ struct StoreRecommendDTO: Decodable {
     let count: Int?
 }
 
-struct FetchStoreRecommendResult {
-    var didUserRecommended: Bool
-    var recommendedCount: Int
-}
-
 struct StoreRecommendRequestDTO: Encodable {
     let storeId: Int
 }
 
 extension StoreRecommendDTO {
-    func toFetchResult() -> FetchStoreRecommendResult {
-        return FetchStoreRecommendResult(
-            didUserRecommended: isRecommendation ?? false,
-            recommendedCount: count ?? 0
-        )
-    }
-
     func toResponseValue() -> RecommendStoreResponseValue {
         return RecommendStoreResponseValue(
             recommendCount: count ?? 0,

--- a/RefillStation/RefillStation/Data/Repositories/MockRepositories.swift
+++ b/RefillStation/RefillStation/Data/Repositories/MockRepositories.swift
@@ -80,6 +80,11 @@ final class MockStoreRepository: StoreRepositoryInterface {
         return MockTask { completion(.success(dummyReviews)) }
     }
 
+    func fetchStoreRecommend(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable? {
+        let dummyResult = FetchStoreRecommendResponseValue(recommendCount: 10, didRecommended: true)
+        return MockTask { completion(.success(dummyResult)) }
+    }
+
     func recommendStore(requestValue: RecommendStoreRequestValue, completion: @escaping (Result<RecommendStoreResponseValue, Error>) -> Void) -> Cancellable? {
         let dummyResponse = RecommendStoreResponseValue(recommendCount: 10, didRecommended: true)
         return MockTask { completion(.success(dummyResponse)) }

--- a/RefillStation/RefillStation/Data/Repositories/StoreRepository.swift
+++ b/RefillStation/RefillStation/Data/Repositories/StoreRepository.swift
@@ -64,6 +64,10 @@ final class StoreRepository: StoreRepositoryInterface {
         }
     }
 
+    func fetchStoreRecommend(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable? {
+        return nil
+    }
+
     func recommendStore(requestValue: RecommendStoreRequestValue, completion: @escaping (Result<RecommendStoreResponseValue, Error>) -> Void) -> Cancellable? {
         let path = "/api/recommendation"
         let method: HTTPMethod = requestValue.type == .recommend ? .post : .delete

--- a/RefillStation/RefillStation/Data/Repositories/StoreRepository.swift
+++ b/RefillStation/RefillStation/Data/Repositories/StoreRepository.swift
@@ -65,7 +65,26 @@ final class StoreRepository: StoreRepositoryInterface {
     }
 
     func fetchStoreRecommend(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable? {
-        return nil
+        let path = "/api/recommendation"
+        guard var request = urlRequest(method: .get, path: path) else {
+            completion(.failure(RepositoryError.urlParseFailed))
+            return nil
+        }
+        guard let requestBody = try? JSONEncoder()
+            .encode(FetchStoreRecommendRequestDTO(storeId: requestValue.storeId)) else {
+            completion(.failure(RepositoryError.requestParseFailed))
+            return nil
+        }
+        request.httpBody = requestBody
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        return networkService.dataTask(request: request) { (result: Result<FetchStoreRecommendDTO, Error>) in
+            switch result {
+            case .success(let fetchStoreRecommendDTO):
+                completion(.success(fetchStoreRecommendDTO.toResponseValue()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 
     func recommendStore(requestValue: RecommendStoreRequestValue, completion: @escaping (Result<RecommendStoreResponseValue, Error>) -> Void) -> Cancellable? {

--- a/RefillStation/RefillStation/Domain/Interfaces/Repositories/StoreRepositoryInterface.swift
+++ b/RefillStation/RefillStation/Domain/Interfaces/Repositories/StoreRepositoryInterface.swift
@@ -12,5 +12,6 @@ protocol StoreRepositoryInterface {
                      completion: @escaping (Result<[Store], Error>) -> Void) -> Cancellable?
     func fetchProducts(requestValue: FetchProductsRequestValue, completion: @escaping (Result<[Product], Error>) -> Void) -> Cancellable?
     func fetchStoreReviews(requestValue: FetchStoreReviewsRequestValue, completion: @escaping (Result<[Review], Error>) -> Void) -> Cancellable?
+    func fetchStoreRecommend(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable?
     func recommendStore(requestValue: RecommendStoreRequestValue, completion: @escaping (Result<RecommendStoreResponseValue, Error>) -> Void) -> Cancellable?
 }

--- a/RefillStation/RefillStation/Domain/UseCases/Store/FetchStoreRecommendUseCase.swift
+++ b/RefillStation/RefillStation/Domain/UseCases/Store/FetchStoreRecommendUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  FetchStoreRecommendUseCase.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2023/02/05.
+//
+
+import Foundation
+
+struct FetchStoreRecommendRequestValue {
+    let storeId: Int
+}
+
+struct FetchStoreRecommendResponseValue {
+    let recommendCount: Int
+    let didRecommended: Bool
+}
+
+protocol FetchStoreRecommendUseCaseInterface {
+    func execute(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable?
+}
+
+final class FetchStoreRecommendUseCaseRequestValue: FetchStoreRecommendUseCaseInterface {
+    private let storeRepository: StoreRepositoryInterface
+
+    init(storeRepository: StoreRepositoryInterface = StoreRepository()) {
+        self.storeRepository = storeRepository
+    }
+
+    func execute(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable? {
+        return nil
+    }
+}

--- a/RefillStation/RefillStation/Domain/UseCases/Store/FetchStoreRecommendUseCase.swift
+++ b/RefillStation/RefillStation/Domain/UseCases/Store/FetchStoreRecommendUseCase.swift
@@ -20,7 +20,7 @@ protocol FetchStoreRecommendUseCaseInterface {
     func execute(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable?
 }
 
-final class FetchStoreRecommendUseCaseRequestValue: FetchStoreRecommendUseCaseInterface {
+final class FetchStoreRecommendUseCase: FetchStoreRecommendUseCaseInterface {
     private let storeRepository: StoreRepositoryInterface
 
     init(storeRepository: StoreRepositoryInterface = StoreRepository()) {
@@ -28,6 +28,8 @@ final class FetchStoreRecommendUseCaseRequestValue: FetchStoreRecommendUseCaseIn
     }
 
     func execute(requestValue: FetchStoreRecommendRequestValue, completion: @escaping (Result<FetchStoreRecommendResponseValue, Error>) -> Void) -> Cancellable? {
-        return nil
+        return storeRepository.fetchStoreRecommend(requestValue: requestValue) { result in
+            completion(result)
+        }
     }
 }

--- a/RefillStation/RefillStation/Infrastructure/URLComponentsExtension.swift
+++ b/RefillStation/RefillStation/Infrastructure/URLComponentsExtension.swift
@@ -1,0 +1,22 @@
+//
+//  URLComponentsExtension.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2023/02/06.
+//
+
+import Foundation
+
+extension URLComponents {
+    func toURLRequest<HTTPBody: Encodable>(method: HTTPMethod, body: HTTPBody? = nil) -> URLRequest? {
+        guard let url = url else { return nil }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = method.name
+        if let body = body {
+            urlRequest.httpBody = try? JSONEncoder().encode(body)
+        }
+
+        return urlRequest
+    }
+}

--- a/RefillStation/RefillStation/Infrastructure/URLComponentsExtension.swift
+++ b/RefillStation/RefillStation/Infrastructure/URLComponentsExtension.swift
@@ -8,13 +8,14 @@
 import Foundation
 
 extension URLComponents {
-    func toURLRequest<HTTPBody: Encodable>(method: HTTPMethod, body: HTTPBody? = nil) -> URLRequest? {
+    func toURLRequest(method: HTTPMethod, httpBody: Data? = nil, contentType: String = "application/json") -> URLRequest? {
         guard let url = url else { return nil }
 
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method.name
-        if let body = body {
-            urlRequest.httpBody = try? JSONEncoder().encode(body)
+        if let httpBody = httpBody {
+            urlRequest.httpBody = httpBody
+            urlRequest.addValue(contentType, forHTTPHeaderField: "Content-Type")
         }
 
         return urlRequest


### PR DESCRIPTION
안녕하세요 클로이~ @anyukyung 
작업 완료되어 PR 보냅니다~!
## 🧴 PR 요약
- 가게 추천수를 받아오는 UseCase 및 Repository 메서드를 제작했습니다.
- 서버의 변경 내역을 반영했습니다.
- URLRequest를 repository에서 private 메서드로 제작했었는데 이를 URLComponents의 Extension 메서드로 분리하였습니다.
- 불필요해진 FetchResult 계층 (DTO와 Entity의 중간계층)을 제거했습니다.

참고사항:
가게 추천하기와 가게 추천수 받아오기는 DTO는 통합할 수 없습니다 (받아오는 인자명이 다름)

##### 📸 ScreenShot

https://user-images.githubusercontent.com/67148595/216860657-513e6f16-708c-4735-bd6a-a4179a7a7bbc.mp4

#### Linked Issue
close #121 
