### PR TITLE
Feature/#123 이미지 업로드 로직 제작

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad
+RefillStation/RefillStation/AWSS3Configuration.xcconfig

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ fastlane/test_output
 iOSInjectionProject/
 RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad
 RefillStation/RefillStation/AWSS3Configuration.xcconfig
+RefillStation/RefillStation/Resources/AWSAccessKey.plist

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad
 RefillStation/Secrets.xcconfig
 RefillStation/RefillStation/AWSS3Configuration.xcconfig
 RefillStation/RefillStation/Resources/AWSAccessKey.plist
+RefillStation/RefillStation/Resources/Secrets.xcconfig

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		3210B52F298F94ED0034CBA7 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52E298F94ED0034CBA7 /* NetworkResult.swift */; };
 		3210B531298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */; };
 		3210B535298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */; };
-		322982EC2990723D0081B288 /* AWSS3 in Frameworks */ = {isa = PBXBuildFile; productRef = 322982EB2990723D0081B288 /* AWSS3 */; };
 		322982EE29907CC20081B288 /* URLComponentsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322982ED29907CC20081B288 /* URLComponentsExtension.swift */; };
 		322982F02990F5000081B288 /* AWSS3Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322982EF2990F5000081B288 /* AWSS3Service.swift */; };
 		322E15E4297A0B3600FE2E2F /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */; };
@@ -49,6 +48,7 @@
 		325985F7294C544400D26A37 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325985F6294C544400D26A37 /* HomeCoordinator.swift */; };
 		325985F9294C54CB00D26A37 /* StoreDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325985F8294C54CB00D26A37 /* StoreDetailDIContainer.swift */; };
 		327524DD2987829F00E033A9 /* CustomerSatisfactionRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327524DC2987829F00E033A9 /* CustomerSatisfactionRepositoryInterface.swift */; };
+		3282FED32992391C00DBFE24 /* AWSAccessKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3282FED22992391C00DBFE24 /* AWSAccessKey.plist */; };
 		329557462951992900F5AB53 /* StoreDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F2D9B22951864700131EB1 /* StoreDetailViewModel.swift */; };
 		329557472951992C00F5AB53 /* StoreDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F2D9B02951862E00131EB1 /* StoreDetailViewController.swift */; };
 		329E80252977FA72004286B0 /* OnboardingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329E80222977FA72004286B0 /* OnboardingCollectionViewCell.swift */; };
@@ -65,6 +65,8 @@
 		32A0F5032981797800A04ECC /* CustomerSatisfactionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A0F5022981797800A04ECC /* CustomerSatisfactionUseCase.swift */; };
 		32A0F50529817B1600A04ECC /* UserInfoRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A0F50429817B1600A04ECC /* UserInfoRepositoryInterface.swift */; };
 		32A0F50729817E1B00A04ECC /* StoreRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A0F50629817E1B00A04ECC /* StoreRepositoryInterface.swift */; };
+		32C17B12299203DB002D607E /* AWSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 32C17B11299203DB002D607E /* AWSCore */; };
+		32C17B14299203DB002D607E /* AWSS3 in Frameworks */ = {isa = PBXBuildFile; productRef = 32C17B13299203DB002D607E /* AWSS3 */; };
 		32C22965297D35BA0019EAF6 /* PumpPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C22964297D35BA0019EAF6 /* PumpPopUpViewController.swift */; };
 		32C22967297E785C0019EAF6 /* ReviewReportPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C22966297E785C0019EAF6 /* ReviewReportPopUpViewController.swift */; };
 		32C3B5702987C4C7004A8872 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = 32C3B56F2987C4C7004A8872 /* Algorithms */; };
@@ -178,7 +180,6 @@
 		3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendDTO.swift; sourceTree = "<group>"; };
 		322982ED29907CC20081B288 /* URLComponentsExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponentsExtension.swift; sourceTree = "<group>"; };
 		322982EF2990F5000081B288 /* AWSS3Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3Service.swift; sourceTree = "<group>"; };
-		322982F1299123830081B288 /* AWSS3Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AWSS3Configuration.xcconfig; sourceTree = "<group>"; };
 		322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
 		322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterReviewDIContainer.swift; sourceTree = "<group>"; };
@@ -212,6 +213,7 @@
 		325985F6294C544400D26A37 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		325985F8294C54CB00D26A37 /* StoreDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDetailDIContainer.swift; sourceTree = "<group>"; };
 		327524DC2987829F00E033A9 /* CustomerSatisfactionRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSatisfactionRepositoryInterface.swift; sourceTree = "<group>"; };
+		3282FED22992391C00DBFE24 /* AWSAccessKey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AWSAccessKey.plist; sourceTree = "<group>"; };
 		329E80222977FA72004286B0 /* OnboardingCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCollectionViewCell.swift; sourceTree = "<group>"; };
 		329E80232977FA72004286B0 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		329E80242977FA72004286B0 /* OnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
@@ -316,10 +318,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32C17B14299203DB002D607E /* AWSS3 in Frameworks */,
 				32C3B5702987C4C7004A8872 /* Algorithms in Frameworks */,
 				32CCC0D129791C9300C04231 /* Toast in Frameworks */,
-				322982EC2990723D0081B288 /* AWSS3 in Frameworks */,
 				3244A238292DCB1F00716A2B /* SnapKit in Frameworks */,
+				32C17B12299203DB002D607E /* AWSCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -387,6 +390,7 @@
 				3244A214292DC13B00716A2B /* RefillStationTests */,
 				3244A21E292DC13B00716A2B /* RefillStationUITests */,
 				3244A1F9292DC13A00716A2B /* Products */,
+				32C503B02991493E0044554E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -410,7 +414,6 @@
 				FCE00A9D29517E4E00B5C05F /* Infrastructure */,
 				FCE00AA42951879A00B5C05F /* Common */,
 				3244A22F292DC17800716A2B /* Resources */,
-				322982F1299123830081B288 /* AWSS3Configuration.xcconfig */,
 			);
 			path = RefillStation;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 				FCEE102E2934CCB8002E629D /* Fonts.swift */,
 				3244A209292DC13A00716A2B /* LaunchScreen.storyboard */,
 				3244A20C292DC13A00716A2B /* Info.plist */,
+				3282FED22992391C00DBFE24 /* AWSAccessKey.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -638,6 +642,13 @@
 				FCE00A7C294C91AD00B5C05F /* RegisterReviewUseCase.swift */,
 			);
 			path = RegisterReview;
+			sourceTree = "<group>";
+		};
+		32C503B02991493E0044554E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		32DDE66029866CCE008AFDB2 /* LoginScene */ = {
@@ -1006,7 +1017,8 @@
 				3244A237292DCB1F00716A2B /* SnapKit */,
 				32CCC0D029791C9300C04231 /* Toast */,
 				32C3B56F2987C4C7004A8872 /* Algorithms */,
-				322982EB2990723D0081B288 /* AWSS3 */,
+				32C17B11299203DB002D607E /* AWSCore */,
+				32C17B13299203DB002D607E /* AWSS3 */,
 			);
 			productName = RefillStation;
 			productReference = 3244A1F8292DC13A00716A2B /* RefillStation.app */;
@@ -1084,7 +1096,7 @@
 				3244A236292DCB1F00716A2B /* XCRemoteSwiftPackageReference "SnapKit" */,
 				32CCC0CF29791C9300C04231 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
 				32C3B56E2987C4C7004A8872 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
-				322982EA2990723D0081B288 /* XCRemoteSwiftPackageReference "aws-sdk-swift" */,
+				32C17B10299203DB002D607E /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */,
 			);
 			productRefGroup = 3244A1F9292DC13A00716A2B /* Products */;
 			projectDirPath = "";
@@ -1104,6 +1116,7 @@
 			files = (
 				3244A233292DC48300716A2B /* .swiftlint.yml in Resources */,
 				FCEE10232934C385002E629D /* Colors.xcassets in Resources */,
+				3282FED32992391C00DBFE24 /* AWSAccessKey.plist in Resources */,
 				3244A20B292DC13A00716A2B /* LaunchScreen.storyboard in Resources */,
 				3244A208292DC13A00716A2B /* Assets.xcassets in Resources */,
 				FCEE10252934C855002E629D /* images.xcassets in Resources */,
@@ -1466,7 +1479,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = RefillStation/RefillStation.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 267JUTDVY2;
@@ -1498,7 +1510,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = RefillStation/RefillStation.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 267JUTDVY2;
@@ -1643,20 +1654,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		322982EA2990723D0081B288 /* XCRemoteSwiftPackageReference "aws-sdk-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/awslabs/aws-sdk-swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.1;
-			};
-		};
 		3244A236292DCB1F00716A2B /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.0.0;
+			};
+		};
+		32C17B10299203DB002D607E /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/aws-amplify/aws-sdk-ios-spm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 		32C3B56E2987C4C7004A8872 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
@@ -1678,15 +1689,20 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		322982EB2990723D0081B288 /* AWSS3 */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 322982EA2990723D0081B288 /* XCRemoteSwiftPackageReference "aws-sdk-swift" */;
-			productName = AWSS3;
-		};
 		3244A237292DCB1F00716A2B /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3244A236292DCB1F00716A2B /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		32C17B11299203DB002D607E /* AWSCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32C17B10299203DB002D607E /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */;
+			productName = AWSCore;
+		};
+		32C17B13299203DB002D607E /* AWSS3 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32C17B10299203DB002D607E /* XCRemoteSwiftPackageReference "aws-sdk-ios-spm" */;
+			productName = AWSS3;
 		};
 		32C3B56F2987C4C7004A8872 /* Algorithms */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -16,8 +16,9 @@
 		3210B52F298F94ED0034CBA7 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52E298F94ED0034CBA7 /* NetworkResult.swift */; };
 		3210B531298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */; };
 		3210B535298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */; };
-		322982EE29907CC20081B288 /* URLComponentsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322982ED29907CC20081B288 /* URLComponentsExtension.swift */; };
 		322982EC2990723D0081B288 /* AWSS3 in Frameworks */ = {isa = PBXBuildFile; productRef = 322982EB2990723D0081B288 /* AWSS3 */; };
+		322982EE29907CC20081B288 /* URLComponentsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322982ED29907CC20081B288 /* URLComponentsExtension.swift */; };
+		322982F02990F5000081B288 /* AWSS3Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322982EF2990F5000081B288 /* AWSS3Service.swift */; };
 		322E15E4297A0B3600FE2E2F /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */; };
 		322E15E6297A0B6600FE2E2F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */; };
 		322E15E8297A0CD700FE2E2F /* RegisterReviewDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */; };
@@ -176,6 +177,8 @@
 		3210B530298FB5730034CBA7 /* FetchStoreRecommendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendUseCase.swift; sourceTree = "<group>"; };
 		3210B534298FBA6B0034CBA7 /* FetchStoreRecommendDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreRecommendDTO.swift; sourceTree = "<group>"; };
 		322982ED29907CC20081B288 /* URLComponentsExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponentsExtension.swift; sourceTree = "<group>"; };
+		322982EF2990F5000081B288 /* AWSS3Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3Service.swift; sourceTree = "<group>"; };
+		322982F1299123830081B288 /* AWSS3Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AWSS3Configuration.xcconfig; sourceTree = "<group>"; };
 		322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
 		322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterReviewDIContainer.swift; sourceTree = "<group>"; };
@@ -407,6 +410,7 @@
 				FCE00A9D29517E4E00B5C05F /* Infrastructure */,
 				FCE00AA42951879A00B5C05F /* Common */,
 				3244A22F292DC17800716A2B /* Resources */,
+				322982F1299123830081B288 /* AWSS3Configuration.xcconfig */,
 			);
 			path = RefillStation;
 			sourceTree = "<group>";
@@ -945,6 +949,7 @@
 			children = (
 				FCE00A9E29517E5600B5C05F /* Network */,
 				322982ED29907CC20081B288 /* URLComponentsExtension.swift */,
+				322982EF2990F5000081B288 /* AWSS3Service.swift */,
 			);
 			path = Infrastructure;
 			sourceTree = "<group>";
@@ -1214,6 +1219,7 @@
 				FCE00A7D294C91AD00B5C05F /* RegisterReviewUseCase.swift in Sources */,
 				32E6AE44298E7EF4005AA542 /* ProductDTO.swift in Sources */,
 				FCF0181D296095AD0027078A /* CTAButton.swift in Sources */,
+				322982F02990F5000081B288 /* AWSS3Service.swift in Sources */,
 				329557472951992C00F5AB53 /* StoreDetailViewController.swift in Sources */,
 				FCD9721C298D7C9000E27792 /* RegionRequestCollectionViewCell.swift in Sources */,
 				325985F9294C54CB00D26A37 /* StoreDetailDIContainer.swift in Sources */,
@@ -1460,6 +1466,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RefillStation/RefillStation.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 267JUTDVY2;
@@ -1491,6 +1498,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RefillStation/RefillStation.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 267JUTDVY2;

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3210B52B298F834B0034CBA7 /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52A298F834B0034CBA7 /* RepositoryError.swift */; };
 		3210B52D298F88410034CBA7 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52C298F88410034CBA7 /* HTTPMethod.swift */; };
 		3210B52F298F94ED0034CBA7 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3210B52E298F94ED0034CBA7 /* NetworkResult.swift */; };
+		322982EC2990723D0081B288 /* AWSS3 in Frameworks */ = {isa = PBXBuildFile; productRef = 322982EB2990723D0081B288 /* AWSS3 */; };
 		322E15E4297A0B3600FE2E2F /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E3297A0B3600FE2E2F /* MyPageDIContainer.swift */; };
 		322E15E6297A0B6600FE2E2F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E5297A0B6600FE2E2F /* MyPageCoordinator.swift */; };
 		322E15E8297A0CD700FE2E2F /* RegisterReviewDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322E15E7297A0CD700FE2E2F /* RegisterReviewDIContainer.swift */; };
@@ -308,6 +309,7 @@
 			files = (
 				32C3B5702987C4C7004A8872 /* Algorithms in Frameworks */,
 				32CCC0D129791C9300C04231 /* Toast in Frameworks */,
+				322982EC2990723D0081B288 /* AWSS3 in Frameworks */,
 				3244A238292DCB1F00716A2B /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -990,6 +992,7 @@
 				3244A237292DCB1F00716A2B /* SnapKit */,
 				32CCC0D029791C9300C04231 /* Toast */,
 				32C3B56F2987C4C7004A8872 /* Algorithms */,
+				322982EB2990723D0081B288 /* AWSS3 */,
 			);
 			productName = RefillStation;
 			productReference = 3244A1F8292DC13A00716A2B /* RefillStation.app */;
@@ -1067,6 +1070,7 @@
 				3244A236292DCB1F00716A2B /* XCRemoteSwiftPackageReference "SnapKit" */,
 				32CCC0CF29791C9300C04231 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
 				32C3B56E2987C4C7004A8872 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
+				322982EA2990723D0081B288 /* XCRemoteSwiftPackageReference "aws-sdk-swift" */,
 			);
 			productRefGroup = 3244A1F9292DC13A00716A2B /* Products */;
 			projectDirPath = "";
@@ -1619,6 +1623,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		322982EA2990723D0081B288 /* XCRemoteSwiftPackageReference "aws-sdk-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/awslabs/aws-sdk-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.1;
+			};
+		};
 		3244A236292DCB1F00716A2B /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -1646,6 +1658,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		322982EB2990723D0081B288 /* AWSS3 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 322982EA2990723D0081B288 /* XCRemoteSwiftPackageReference "aws-sdk-swift" */;
+			productName = AWSS3;
+		};
 		3244A237292DCB1F00716A2B /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3244A236292DCB1F00716A2B /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -400,7 +400,6 @@
 		3244A1EF292DC13A00716A2B = {
 			isa = PBXGroup;
 			children = (
-				FCB00888299153FA0006FF53 /* Secrets.xcconfig */,
 				3244A232292DC48300716A2B /* .swiftlint.yml */,
 				FCEE10262934C8EE002E629D /* swiftgen.yml */,
 				3244A1FA292DC13A00716A2B /* RefillStation */,
@@ -475,6 +474,7 @@
 				FCEE102E2934CCB8002E629D /* Fonts.swift */,
 				3244A209292DC13A00716A2B /* LaunchScreen.storyboard */,
 				3244A20C292DC13A00716A2B /* Info.plist */,
+				FCB00888299153FA0006FF53 /* Secrets.xcconfig */,
 				3282FED22992391C00DBFE24 /* AWSAccessKey.plist */,
 			);
 			path = Resources;

--- a/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
+++ b/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
@@ -1,0 +1,60 @@
+//
+//  AWSS3Service.swift
+//  RefillStation
+//
+//  Created by 천수현 on 2023/02/06.
+//
+
+import UIKit
+import AWSS3
+import ClientRuntime
+import AWSClientRuntime
+
+enum AWSS3Error: Error {
+    case imageDataConvertFailed
+}
+
+public class AWSS3Service {
+    enum BucketType {
+        case review
+        case store
+
+        var bucketName: String {
+            return "pump-img-bucket"
+        }
+
+        var URL: String {
+            switch self {
+            case .review:
+                return "https://pump-img-bucket.s3.ap-northeast-2.amazonaws.com/review"
+            case .store:
+                return "https://pump-img-bucket.s3.ap-northeast-2.amazonaws.com/store"
+            }
+        }
+    }
+
+    let client: S3Client
+
+    public init() async {
+        do {
+            client = try await S3Client()
+        } catch {
+            fatalError()
+        }
+    }
+
+    func uploadImage(type: BucketType, key: String, image: UIImage?) async throws -> String {
+        guard let imageData = image?.jpegData(compressionQuality: 1) else { throw AWSS3Error.imageDataConvertFailed }
+        let dataStream = ByteStream.from(data: imageData)
+
+        let input = PutObjectInput(
+            body: dataStream,
+            bucket: type.bucketName,
+            key: key
+        )
+
+        _ = try await client.putObject(input: input)
+
+        return type.URL + "/\(key)"
+    }
+}

--- a/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
+++ b/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
@@ -7,54 +7,86 @@
 
 import UIKit
 import AWSS3
-import ClientRuntime
-import AWSClientRuntime
+import AWSCore
 
 enum AWSS3Error: Error {
     case imageDataConvertFailed
 }
 
 public class AWSS3Service {
-    enum BucketType {
+    enum Bucket {
         case review
         case store
 
-        var bucketName: String {
-            return "pump-img-bucket"
-        }
+        static let bucketName = "pump-img-bucket"
+        static let baseURL = "https://pump-img-bucket.s3.ap-northeast-2.amazonaws.com"
 
-        var URL: String {
+        var name: String {
             switch self {
             case .review:
-                return "https://pump-img-bucket.s3.ap-northeast-2.amazonaws.com/review"
+                return "review"
             case .store:
-                return "https://pump-img-bucket.s3.ap-northeast-2.amazonaws.com/store"
+                return "store"
             }
         }
     }
 
-    let client: S3Client
-
-    public init() async {
-        do {
-            client = try await S3Client()
-        } catch {
-            fatalError()
-        }
+    private var path: String {
+        guard let path = Bundle.main.path(forResource: "AWSAccessKey", ofType: "plist") else { return "" }
+        return path
     }
 
-    func uploadImage(type: BucketType, key: String, image: UIImage?) async throws -> String {
-        guard let imageData = image?.jpegData(compressionQuality: 1) else { throw AWSS3Error.imageDataConvertFailed }
-        let dataStream = ByteStream.from(data: imageData)
+    private var accessKey: String {
+        guard let dictionary = NSDictionary(contentsOfFile: path),
+              let key = dictionary["AWS_ACCESS_KEY"] as? String else { return "" }
+        return key
+    }
 
-        let input = PutObjectInput(
-            body: dataStream,
-            bucket: type.bucketName,
-            key: key
+    private var secretKey: String {
+        guard let dictionary = NSDictionary(contentsOfFile: path),
+              let key = dictionary["AWS_SECRET_KEY"] as? String else { return "" }
+        return key
+    }
+
+    private var region: String {
+        guard let dictionary = NSDictionary(contentsOfFile: path),
+              let key = dictionary["AWS_REGION"] as? String else { return "" }
+        return key
+    }
+
+    static let shared = AWSS3Service()
+
+    init() {
+        let credentialsProvider = AWSStaticCredentialsProvider(accessKey: accessKey, secretKey: secretKey)
+        let configuration = AWSServiceConfiguration(region: .APNortheast2, credentialsProvider: credentialsProvider)
+        AWSServiceManager.default().defaultServiceConfiguration = configuration
+
+        let tuConf = AWSS3TransferUtilityConfiguration()
+        tuConf.isAccelerateModeEnabled = false
+
+        AWSS3TransferUtility.register(
+            with: configuration!,
+            transferUtilityConfiguration: tuConf,
+            forKey: "utility-key"
         )
+    }
 
-        _ = try await client.putObject(input: input)
+    func upload(type: Bucket, image: UIImage?, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: "utility-key"),
+              let imageData = image?.jpegData(compressionQuality: 1) else { return }
 
-        return type.URL + "/\(key)"
+        let id = UUID().uuidString
+        let fileKey = "\(type.name)/\(id).jpeg"
+
+        transferUtility.uploadData(
+            imageData,
+            bucket: Bucket.bucketName,
+            key: fileKey,
+            contentType: "image/jpeg",
+            expression: nil) { task, error in
+                print(error)
+                guard error == nil else { return }
+                completion(.success(Bucket.baseURL + "/" + fileKey))
+            }
     }
 }

--- a/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
+++ b/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
@@ -54,7 +54,7 @@ public class AWSS3Service {
 
     static let shared = AWSS3Service()
 
-    init() {
+    private init() {
         let credentialsProvider = AWSStaticCredentialsProvider(accessKey: accessKey, secretKey: secretKey)
         let configuration = AWSServiceConfiguration(region: .APNortheast2, credentialsProvider: credentialsProvider)
         AWSServiceManager.default().defaultServiceConfiguration = configuration


### PR DESCRIPTION
안녕하세요 클로이~ @anyukyung 
s3에 이미지를 업로드하는 로직이 제작되어 PR 보냅니다!

## 🧴 PR 요약
- AWS S3에 이미지 업로드할 로직 제작
- 업로드 이후에는 이미지의 전체 경로를 반환

#### 📌 변경 사항
- secret config 파일의 위치가 리소스 폴더 안으로 이동되었습니다.

#### 테스트한 이미지 경로
`https://pump-img-bucket.s3.ap-northeast-2.amazonaws.com/store/747D08C8-D224-45B1-81C9-6A1115062AAD.jpeg`

#### Linked Issue
close #123
