### PR TITLE
[Feature/#149] 로그인시 User의 Type 추가, email과 name 옵셔널로 변경, 로그아웃/탈퇴시 로그인 뷰로 보내는 로직 추가

### DIFF
--- a/RefillStation/RefillStation/Data/DTOs/Account/LoginDTO.swift
+++ b/RefillStation/RefillStation/Data/DTOs/Account/LoginDTO.swift
@@ -13,8 +13,8 @@ struct LoginDTO: Decodable {
 
 extension LoginDTO {
     func toDomain() -> OAuthLoginResponseValue {
-        return OAuthLoginResponseValue(name: name ?? "",
-                                       email: email ?? "",
+        return OAuthLoginResponseValue(name: name,
+                                       email: email,
                                        imgPath: imgPath ?? "",
                                        oauthIdentity: oauthIdentity ?? "",
                                        oauthType: oauthType ?? "",

--- a/RefillStation/RefillStation/Data/DTOs/Account/SignUpDTO.swift
+++ b/RefillStation/RefillStation/Data/DTOs/Account/SignUpDTO.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct SignUpReqeustDTO: Encodable {
-    let name: String
-    let email: String
+    let name: String?
+    let email: String?
     let imagePath: String
     let type: String = "USER"
     let oauthType: String

--- a/RefillStation/RefillStation/Data/DTOs/Account/SignUpDTO.swift
+++ b/RefillStation/RefillStation/Data/DTOs/Account/SignUpDTO.swift
@@ -11,6 +11,7 @@ struct SignUpReqeustDTO: Encodable {
     let name: String
     let email: String
     let imagePath: String
+    let type: String = "USER"
     let oauthType: String
     let oauthIdentity: String
 }

--- a/RefillStation/RefillStation/Domain/UseCases/Account/OAuthLoginUseCase.swift
+++ b/RefillStation/RefillStation/Domain/UseCases/Account/OAuthLoginUseCase.swift
@@ -28,8 +28,8 @@ struct OAuthLoginRequestValue {
 }
 
 struct OAuthLoginResponseValue {
-    let name: String
-    let email: String
+    let name: String?
+    let email: String?
     let imgPath: String
     let oauthIdentity: String
     let oauthType: String

--- a/RefillStation/RefillStation/Domain/UseCases/Account/SignUpUseCase.swift
+++ b/RefillStation/RefillStation/Domain/UseCases/Account/SignUpUseCase.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct SignUpRequestValue {
-    let name: String
-    let email: String
+    let name: String?
+    let email: String?
     let imagePath: String
     let oauthType: String
     let oauthIdentity: String

--- a/RefillStation/RefillStation/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/RefillStation/RefillStation/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -16,7 +16,7 @@ final class LoginViewController: UIViewController {
     private let authorizationController: ASAuthorizationController = {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
-        request.requestedScopes = []
+        request.requestedScopes = [.fullName, .email]
         return ASAuthorizationController(authorizationRequests: [request])
     }()
 
@@ -173,7 +173,18 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             guard let identityToken = appleIDCredential.identityToken,
                   let token = String(data: identityToken, encoding: .utf8) else { return }
-            viewModel.onAppleLoginByAppTouched(requestValue: token)
+
+            let email = appleIDCredential.email
+            var name: String?
+
+            if let familyName = appleIDCredential.fullName?.familyName,
+               let givenName = appleIDCredential.fullName?.givenName {
+                name = familyName + givenName
+            }
+
+            viewModel.onAppleLoginByAppTouched(token: token,
+                                               name: name,
+                                               email: email)
         }
     }
 

--- a/RefillStation/RefillStation/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/RefillStation/RefillStation/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -171,20 +171,7 @@ extension LoginViewController: ASAuthorizationControllerPresentationContextProvi
 extension LoginViewController: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            guard let identityToken = appleIDCredential.identityToken,
-                  let token = String(data: identityToken, encoding: .utf8) else { return }
-
-            let email = appleIDCredential.email
-            var name: String?
-
-            if let familyName = appleIDCredential.fullName?.familyName,
-               let givenName = appleIDCredential.fullName?.givenName {
-                name = familyName + givenName
-            }
-
-            viewModel.onAppleLoginByAppTouched(token: token,
-                                               name: name,
-                                               email: email)
+            viewModel.onAppleLoginByAppTouched(appleIDCredential: appleIDCredential)
         }
     }
 

--- a/RefillStation/RefillStation/Presentation/LoginScene/ViewModel/LoginViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/LoginScene/ViewModel/LoginViewModel.swift
@@ -13,6 +13,8 @@ final class LoginViewModel {
     private let OAuthLoginUseCase: OAuthLoginUseCaseInterface
 
     var signUpRequestValue: SignUpRequestValue?
+    private var appleUserName: String?
+    private var appleUserEmail: String?
     var isSignUp: (() -> Void)?
     var isSignIn: (() -> Void)?
 
@@ -27,9 +29,11 @@ final class LoginViewModel {
                     loginType: oauthType,
                     requestValue: OAuthLoginRequestValue(accessToken: requestValue)
                 )
+                let name = oauthType == .apple ? appleUserName : result.name
+                let email = oauthType == .apple ? appleUserEmail : result.email
                 self.signUpRequestValue = SignUpRequestValue(
-                    name: result.name,
-                    email: result.email,
+                    name: name,
+                    email: email,
                     imagePath: result.imgPath,
                     oauthType: result.oauthType,
                     oauthIdentity: result.oauthIdentity
@@ -67,8 +71,12 @@ extension LoginViewModel {
 
     }
 
-    func onAppleLoginByAppTouched(requestValue: String) {
+    func onAppleLoginByAppTouched(token: String,
+                                  name: String?,
+                                  email: String?) {
         self.loginButtonDidTapped(oauthType: .apple,
-                                  requestValue: requestValue)
+                                  requestValue: token)
+        self.appleUserName = name
+        self.appleUserEmail = email
     }
 }

--- a/RefillStation/RefillStation/Presentation/LoginScene/ViewModel/LoginViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/LoginScene/ViewModel/LoginViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import KakaoSDKUser
 import KakaoSDKAuth
+import AuthenticationServices
 
 final class LoginViewModel {
     private let OAuthLoginUseCase: OAuthLoginUseCaseInterface
@@ -49,9 +50,6 @@ final class LoginViewModel {
 extension LoginViewModel {
 
     // MARK: - ViewController의 LoginButton이 눌릴 때 호출되는 메소드
-    private func loginButtonDidTapped(oauthType: OAuthType, requestValue: String) {
-        requestLogin(oauthType: oauthType, requestValue: requestValue)
-    }
 
     func onKakaoLoginByAppTouched() {
         if UserApi.isKakaoTalkLoginAvailable() {
@@ -60,23 +58,24 @@ extension LoginViewModel {
                     print(error)
                 } else {
                     guard let accessToken = oauthToken?.accessToken else { return }
-                    self.loginButtonDidTapped(oauthType: .kakao,
-                                              requestValue: accessToken)
+                    self.requestLogin(oauthType: .kakao, requestValue: accessToken)
                 }
             }
         }
     }
 
-    func onNaverLoginByAppTouched() {
-
+    func onAppleLoginByAppTouched(appleIDCredential: ASAuthorizationAppleIDCredential) {
+        guard let identityToken = appleIDCredential.identityToken,
+              let token = String(data: identityToken, encoding: .utf8) else { return }
+        appleUserEmail = appleIDCredential.email
+        if let familyName = appleIDCredential.fullName?.familyName,
+           let givenName = appleIDCredential.fullName?.givenName {
+            appleUserName = familyName + givenName
+        }
+        self.requestLogin(oauthType: .apple, requestValue: token)
     }
 
-    func onAppleLoginByAppTouched(token: String,
-                                  name: String?,
-                                  email: String?) {
-        self.loginButtonDidTapped(oauthType: .apple,
-                                  requestValue: token)
-        self.appleUserName = name
-        self.appleUserEmail = email
+    func onNaverLoginByAppTouched() {
+
     }
 }

--- a/RefillStation/RefillStation/Presentation/MyPageScene/ViewModel/AccountManagementViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/MyPageScene/ViewModel/AccountManagementViewModel.swift
@@ -22,6 +22,7 @@ final class AccountManagementViewModel {
         Task {
             do {
                 try await signOutUseCase.execute()
+                presentToLogin?()
             } catch {
                 print(error)
             }
@@ -32,6 +33,7 @@ final class AccountManagementViewModel {
         Task {
             do {
                 try await withdrawUseCase.execute()
+                presentToLogin?()
             } catch {
                 print(error)
             }


### PR DESCRIPTION
## 🧴 PR 요약
해당 pr에서 작업한 내역을 적어주세요.

- 로그인시 User의 Type 추
- email과 name 옵셔널로 변경
- 로그아웃/탈퇴시 로그인 뷰로 보내는 로직 추가
- 애플로그인 로직 뷰모델로 이동 및 name과 email 받아오는 로직 추가

#### 📌 변경 사항
변경사항 및 주의 사항(모듈 설치 등)을 적어주세요.

```swift
struct SignUpDTO {
    let name: String
    let email: String
    let imagePath: String
    let type: String = "USER" // added
    let oauthType: String
    let oauthIdentity: String
}
```

```swift
struct SignUpRequestValue {
    let name: String?
    let email: String? 
    let imagePath: String
    let oauthType: String
    let oauthIdentity: String
}
```

```swift
struct OAuthLoginResponseValue {
    let name: String?
    let email: String?
    let imgPath: String
    let oauthIdentity: String
    let oauthType: String
}
```

##### 📸 ScreenShot
PR과 관련된 화면을 첨부해주세요.

##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #149 
