### PR TITLE
[Fix] #155 라벨의 높이를 컨텐츠를 통해 계산하게하여 한줄만 나오던 에러 해결

### DIFF
--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/Review/DetailReviewCell.swift
@@ -263,6 +263,12 @@ final class DetailReviewCell: UICollectionViewCell {
             outerStackView.setCustomSpacing(0, after: reviewInfoView)
         }
 
+        var newSize = descriptionLabel.sizeThatFits(descriptionLabel.frame.size)
+        newSize = descriptionLabel.sizeThatFits(CGSize(width: contentView.frame.width - 32,
+                                         height: CGFloat.greatestFiniteMagnitude))
+        descriptionLabel.snp.remakeConstraints {
+            $0.height.equalTo(newSize.height).priority(.required)
+        }
         if !review.description.isEmpty {
             outerStackView.setCustomSpacing(18, after: reviewImageOuterView)
         } else {

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -261,7 +261,6 @@ extension StoreDetailViewController: UICollectionViewDelegate {
             var currentSnapshot = storeDetailDataSource.snapshot()
             currentSnapshot.reloadItems([item])
             storeDetailDataSource.apply(currentSnapshot)
-            collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: true)
         }
     }
 


### PR DESCRIPTION
## 🧴 PR 요약
- 라벨의 높이를 계산하는 로직을 통해 라벨이 알맞은 높이를 가질 수 있도록 수정하였습니다.
- 셀을 리로드할때 셀을 화면 중앙에 위치하게 스크롤 하던것이 부자연스럽다 느껴져서 삭제했습니다.

##### 📸 ScreenShot
### 전후 비교
| ![Simulator Screen Shot - iPhone 13 Pro - 2023-02-12 at 23.41.22](https://raw.githubusercontent.com/Neph3779/Blog-Image/forUpload/img/20230212234511.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2023-02-12 at 23.42.29](https://raw.githubusercontent.com/Neph3779/Blog-Image/forUpload/img/20230212234516.png) |
| :----------------------------------------------------------: | :----------------------------------------------------------: |
|                             이전                             |                             이후                             |

### 리로드 자연스러움 개선

https://user-images.githubusercontent.com/67148595/218317993-ec0526ba-8d85-4af9-a0ab-24c700dc88ac.mp4



#### Linked Issue
close #155
