### PR TITLE
Qa/#169 1.0(9) 대응

### DIFF
--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -89,7 +89,7 @@ final class StoreDetailViewController: UIViewController, ServerAlertable {
         scrollEdgeAppearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.clear]
         navigationController?.navigationBar.standardAppearance = standardAppearance
         navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
-        navigationController?.navigationBar.tintColor = .white
+        navigationController?.navigationBar.tintColor = collectionView.contentOffset.y > 0 ? .black : .white
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
         navigationItem.title = viewModel.store.name
     }


### PR DESCRIPTION
## 🧴 PR 요약
- 리뷰 이미지를 phPicker로부터 로드하여 화면에 띄워주는 로직을 async await로 리팩토링 하였습니다.
  - loadObject의 task 시작이 나중에 되어도 먼저 종료되어 dispatchGroup을 leave 할 수 있던 문제를 해결했습니다.
  - 모종의 이유로 리뷰 이미지가 3장 초과하여 올라가는 일이 절대 발생하지 않도록 prefix(3)으로 개수 고정했습니다.
  - addPhotos는 다른 곳에서 호출할 UI작업 메서드이므로 메인쓰레드에서 동작하도록 명시적으로 지정했습니다.
- 가게 화면으로 pop해서 들어왔을때 네비바의 tintColor가 white로 지정되어 백버튼이 보이지 않던 문제를 해결했습니다.


## 📸 ScreenShot

#### 이전
https://user-images.githubusercontent.com/67148595/218633906-aef821db-2904-4054-ace3-31da7f0c0c98.mp4

#### 이후
https://user-images.githubusercontent.com/67148595/218637413-a0fc1b28-39b5-4839-9148-eb880257236d.mp4




#### Linked Issue
close #169 
