### PR TITLE
[Fix] #177 PHPicker 버그 해결

### DIFF
--- a/RefillStation/RefillStation/Presentation/RegisterReviewScene/View/ReviewPhotosCell.swift
+++ b/RefillStation/RefillStation/Presentation/RegisterReviewScene/View/ReviewPhotosCell.swift
@@ -14,7 +14,7 @@ final class ReviewPhotosCell: UICollectionViewCell {
     static let reuseIdentifier = String(describing: ReviewPhotosCell.self)
     weak var delegate: ReviewPhotoDelegate?
     private let outerScrollView = UIScrollView()
-    var isReviewImageLoading = false
+    private var isReviewImageLoading = false
 
     private let dividerView: UIView = {
         let view = UIView()

--- a/RefillStation/RefillStation/Presentation/RegisterReviewScene/View/ReviewPhotosCell.swift
+++ b/RefillStation/RefillStation/Presentation/RegisterReviewScene/View/ReviewPhotosCell.swift
@@ -14,6 +14,7 @@ final class ReviewPhotosCell: UICollectionViewCell {
     static let reuseIdentifier = String(describing: ReviewPhotosCell.self)
     weak var delegate: ReviewPhotoDelegate?
     private let outerScrollView = UIScrollView()
+    var isReviewImageLoading = false
 
     private let dividerView: UIView = {
         let view = UIView()
@@ -127,6 +128,8 @@ final class ReviewPhotosCell: UICollectionViewCell {
 
 extension ReviewPhotosCell: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        guard !isReviewImageLoading else { return }
+        isReviewImageLoading = true
         let items = results.map { $0.itemProvider }
         removeAllPhotoImages()
         Task {
@@ -139,6 +142,7 @@ extension ReviewPhotosCell: PHPickerViewControllerDelegate {
             }
             addPhotos()
             delegate?.dismiss(reviewPhotos: photoImages)
+            isReviewImageLoading = false
         }
     }
 


### PR DESCRIPTION
## 🧴 PR 요약
- PHPicker의 내부 버그로 인해 completion이 두번 호출되고 있었기에 이를 isReviewImageLoading이라는 플래그를 통해 막아주었습니다.
![image](https://user-images.githubusercontent.com/67148595/218913488-f8abe140-15ed-4a0b-a84b-b94bb7cf0daa.png)


#### Linked Issue
close #177 
