### PR TITLE
Qa/#200

### DIFF
--- a/RefillStation/RefillStation/Data/Repositories/AsyncAccountRepository.swift
+++ b/RefillStation/RefillStation/Data/Repositories/AsyncAccountRepository.swift
@@ -72,6 +72,7 @@ final class AsyncAccountRepository: AsyncAccountRepositoryInterface {
     }
 
     func withdraw() async throws {
+        _ = KeychainManager.shared.deleteItem(key: "lookAroundToken")
         guard KeychainManager.shared.getItem(key: "token") != nil else { return }
         var urlComponents = URLComponents(string: networkService.baseURL)
         urlComponents?.path = "/api/user"


### PR DESCRIPTION
## 🧴 PR 요약
- 회원 탈퇴시 둘러보기용을 삭제하여 둘러보기용 계정의 회원탈퇴를 막았습니다.
- swift task continuation misuse: leaked its continuation라는 오류를 방지하기 위해 CLGeocoder().reverseGeocodeLocation(location, preferredLocale: locale) 메서드를 공식 async await 지원 메서드로 교체했습니다.

#### Linked Issue
close #200 
