### PR TITLE
Qa/#206

### DIFF
--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -1716,7 +1716,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Hola.RefillStation.Pump;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1753,7 +1753,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Hola.RefillStation.Pump;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/RefillStation/RefillStation/Application/AppDelegate.swift
+++ b/RefillStation/RefillStation/Application/AppDelegate.swift
@@ -40,17 +40,38 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     static func setUpNavigationBar() {
         let appearance = UINavigationBarAppearance()
-        let backButtonImage: UIImage? = {
-            return Asset.Images.iconArrowLeft.image.withAlignmentRectInsets(
-                UIEdgeInsets(top: 0.0, left: -8.0, bottom: 0, right: 0.0)
-            )
-        }()
-        appearance.configureWithTransparentBackground()
+        let backButtonImage = Asset.Images.iconArrowLeft.image.withAlignmentRectInsets(
+            UIEdgeInsets(top: 0.0, left: -8.0, bottom: 0, right: 0.0)
+        )
+        appearance.configureWithDefaultBackground()
         appearance.backgroundColor = .clear
         appearance.shadowColor = Asset.Colors.gray2.color
         appearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
+    }
+
+    static func navigationBarStandardAppearance() -> UINavigationBarAppearance {
+        let backButtonImage = Asset.Images.iconArrowLeft.image
+            .withAlignmentRectInsets(.init(top: 0, left: -8, bottom: 0, right: 0))
+        let standardAppearance = UINavigationBarAppearance()
+        standardAppearance.configureWithDefaultBackground()
+        standardAppearance.backgroundColor = .white
+        standardAppearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.black]
+        standardAppearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
+        return standardAppearance
+    }
+
+    static func navigationBarScrollEdgeAppearance() -> UINavigationBarAppearance {
+        let backButtonImage = Asset.Images.iconArrowLeft.image.withAlignmentRectInsets(
+            UIEdgeInsets(top: 0.0, left: -8.0, bottom: 0, right: 0.0)
+        )
+        let scrollEdgeAppearance = UINavigationBarAppearance()
+        scrollEdgeAppearance.configureWithDefaultBackground()
+        scrollEdgeAppearance.backgroundColor = .white
+        scrollEdgeAppearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.black]
+        scrollEdgeAppearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
+        return scrollEdgeAppearance
     }
 
     func application(_ app: UIApplication,

--- a/RefillStation/RefillStation/Application/AppDelegate.swift
+++ b/RefillStation/RefillStation/Application/AppDelegate.swift
@@ -40,9 +40,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     static func setUpNavigationBar() {
         let appearance = UINavigationBarAppearance()
-        let backButtonImage = Asset.Images.iconArrowLeft.image.withAlignmentRectInsets(
-            UIEdgeInsets(top: 0.0, left: -8.0, bottom: 0, right: 0.0)
-        )
+        let backButtonImage = Asset.Images.iconArrowLeft.image
+            .withAlignmentRectInsets(.init(top: 0, left: -8, bottom: 0, right: 0))
         appearance.configureWithDefaultBackground()
         appearance.backgroundColor = .clear
         appearance.shadowColor = Asset.Colors.gray2.color
@@ -63,9 +62,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     static func navigationBarScrollEdgeAppearance() -> UINavigationBarAppearance {
-        let backButtonImage = Asset.Images.iconArrowLeft.image.withAlignmentRectInsets(
-            UIEdgeInsets(top: 0.0, left: -8.0, bottom: 0, right: 0.0)
-        )
+        let backButtonImage = Asset.Images.iconArrowLeft.image
+            .withAlignmentRectInsets(.init(top: 0, left: -8, bottom: 0, right: 0))
         let scrollEdgeAppearance = UINavigationBarAppearance()
         scrollEdgeAppearance.configureWithDefaultBackground()
         scrollEdgeAppearance.backgroundColor = .white

--- a/RefillStation/RefillStation/Data/KeychainManager.swift
+++ b/RefillStation/RefillStation/Data/KeychainManager.swift
@@ -32,7 +32,7 @@ final class KeychainManager {
                 return updateItem(key: key, value: value)
             }
 
-            print("addItem Error : \(status.description))")
+            print("addItem Error : \(key))")
             return false
         }()
 
@@ -57,7 +57,7 @@ final class KeychainManager {
             }
         }
 
-        print("getItem Error : \(result.description)")
+        print("getItem Error : \(key)")
         return nil
     }
 
@@ -72,7 +72,7 @@ final class KeychainManager {
             let status = SecItemUpdate(prevQuery as CFDictionary, updateQuery as CFDictionary)
             if status == errSecSuccess { return true }
 
-            print("updateItem Error : \(status.description)")
+            print("updateItem Error : \(key)")
             return false
         }()
 
@@ -85,7 +85,7 @@ final class KeychainManager {
         let status = SecItemDelete(deleteQuery as CFDictionary)
         if status == errSecSuccess { return true }
 
-        print("deleteItem Error : \(status.description)")
+        print("deleteItem Error : \(key)")
         return false
     }
 

--- a/RefillStation/RefillStation/Infrastructure/Network/NetworkService.swift
+++ b/RefillStation/RefillStation/Infrastructure/Network/NetworkService.swift
@@ -81,6 +81,12 @@ final class NetworkService: NetworkServiceInterface {
     }
 
     func dataTask<DTO: Decodable>(request: URLRequest) async throws -> DTO {
+        var request = request
+        if let token {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        } else {
+            print("There is no jwt token")
+        }
         if #available(iOS 15, *) {
             let (data, response) = try await URLSession.shared.data(for: request)
             print("🌐 " + (request.httpMethod ?? "") + " : " + String(request.url?.absoluteString ?? ""))
@@ -101,13 +107,6 @@ final class NetworkService: NetworkServiceInterface {
             return dto
         } else {
             return try await withCheckedThrowingContinuation({ continuation in
-                var request = request
-                if let token {
-                    request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-                } else {
-                    print("There is no jwt token")
-                }
-
                 URLSession.shared.dataTask(with: request) { data, response, error in
                     if error != nil {
                         continuation.resume(throwing: NetworkError.sessionError)

--- a/RefillStation/RefillStation/Infrastructure/Network/NetworkService.swift
+++ b/RefillStation/RefillStation/Infrastructure/Network/NetworkService.swift
@@ -81,29 +81,61 @@ final class NetworkService: NetworkServiceInterface {
     }
 
     func dataTask<DTO: Decodable>(request: URLRequest) async throws -> DTO {
-        var request = request
-        if let token {
-            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        } else {
-            print("There is no jwt token")
-        }
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        print("🌐 " + (request.httpMethod ?? "") + " : " + String(request.url?.absoluteString ?? ""))
-        guard let httpResponse = response as? HTTPURLResponse,
-              200...299 ~= httpResponse.statusCode else {
-            guard let exception = try? JSONDecoder().decode(Exception.self, from: data) else {
-                print("🚨 data: " + (String(data: data, encoding: .utf8) ?? ""))
-                throw NetworkError.exceptionParseFailed
+        if #available(iOS 15, *) {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            print("🌐 " + (request.httpMethod ?? "") + " : " + String(request.url?.absoluteString ?? ""))
+            guard let httpResponse = response as? HTTPURLResponse,
+                  200...299 ~= httpResponse.statusCode else {
+                guard let exception = try? JSONDecoder().decode(Exception.self, from: data) else {
+                    print("🚨 data: " + (String(data: data, encoding: .utf8) ?? ""))
+                    throw NetworkError.exceptionParseFailed
+                }
+                print("🚨 status: \(exception.status) \n message: \(exception.message)")
+                throw NetworkError.exception(errorMessage: exception.message)
             }
-            print("🚨 status: \(exception.status) \n message: \(exception.message)")
-            throw NetworkError.exception(errorMessage: exception.message)
-        }
 
-        guard let dto = try? JSONDecoder().decode(NetworkResult<DTO>.self, from: data).data else {
-            throw NetworkError.jsonParseFailed
+            guard let dto = try? JSONDecoder().decode(NetworkResult<DTO>.self, from: data).data else {
+                throw NetworkError.jsonParseFailed
+            }
+            print("✅ status: \(httpResponse.statusCode)")
+            return dto
+        } else {
+            return try await withCheckedThrowingContinuation({ continuation in
+                var request = request
+                if let token {
+                    request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                } else {
+                    print("There is no jwt token")
+                }
+
+                URLSession.shared.dataTask(with: request) { data, response, error in
+                    if error != nil {
+                        continuation.resume(throwing: NetworkError.sessionError)
+                        return
+                    }
+                    print("🌐 request: " + String(response?.url?.absoluteString ?? ""))
+                    guard let httpResponse = response as? HTTPURLResponse,
+                          200...299 ~= httpResponse.statusCode else {
+                        guard let data = data,
+                              let exception = try? JSONDecoder().decode(Exception.self, from: data) else {
+                            continuation.resume(throwing: NetworkError.exceptionParseFailed)
+                            print("🚨 data: " + (String(data: data!, encoding: .utf8) ?? ""))
+                            return
+                        }
+                        continuation.resume(throwing: NetworkError.exception(errorMessage: exception.message))
+                        print("🚨 status: \(exception.status) \n message: \(exception.message)")
+                        return
+                    }
+
+                    guard let data = data,
+                          let dto = try? JSONDecoder().decode(NetworkResult<DTO>.self, from: data).data else {
+                        continuation.resume(throwing: NetworkError.jsonParseFailed)
+                        return
+                    }
+                    print("✅ status: \(httpResponse.statusCode)")
+                    continuation.resume(returning: dto)
+                }.resume()
+            })
         }
-        print("✅ status: \(httpResponse.statusCode)")
-        return dto
     }
 }

--- a/RefillStation/RefillStation/Presentation/RegisterReviewScene/Section.swift
+++ b/RefillStation/RefillStation/Presentation/RegisterReviewScene/Section.swift
@@ -26,7 +26,7 @@ extension RegisterReviewViewController {
             case .storeInfo:
                 defaultItem.contentInsets = .init(top: 5, leading: 0, bottom: 0, trailing: 0)
                 let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                                       heightDimension: .absolute(60))
+                                                       heightDimension: .absolute(80))
                 let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [defaultItem])
                 section = NSCollectionLayoutSection(group: group)
             case .voteTitle:

--- a/RefillStation/RefillStation/Presentation/RegisterReviewScene/View/StoreInfoCell.swift
+++ b/RefillStation/RefillStation/Presentation/RegisterReviewScene/View/StoreInfoCell.swift
@@ -53,7 +53,7 @@ final class StoreInfoCell: UICollectionViewCell {
         }
 
         storeNamelabel.snp.makeConstraints { label in
-            label.top.equalToSuperview()
+            label.top.equalToSuperview().inset(20)
             label.leading.trailing.equalToSuperview().inset(16)
         }
 

--- a/RefillStation/RefillStation/Presentation/RegisterReviewScene/ViewController/RegisterReviewViewController.swift
+++ b/RefillStation/RefillStation/Presentation/RegisterReviewScene/ViewController/RegisterReviewViewController.swift
@@ -77,6 +77,8 @@ final class RegisterReviewViewController: UIViewController, ServerAlertable {
 
     override func viewWillAppear(_ animated: Bool) {
         tabBarController?.tabBar.isHidden = true
+        navigationController?.navigationBar.standardAppearance = AppDelegate.navigationBarStandardAppearance()
+        navigationController?.navigationBar.scrollEdgeAppearance = AppDelegate.navigationBarScrollEdgeAppearance()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -476,7 +476,11 @@ extension StoreDetailViewController {
             .CellRegistration<OperationInfoCell, StoreDetailItem> { [weak self] (cell, indexPath, item) in
                 guard case let .operationInfo(operationInfo) = item, let self = self else { return }
                 let shouldShowMore = self.viewModel.operationInfoSeeMoreIndexPaths.contains(indexPath)
-                cell.setUpContents(operation: operationInfo, shouldShowMore: shouldShowMore)
+                cell.setUpContents(
+                    operation: operationInfo,
+                    shouldShowMore: shouldShowMore,
+                    shouldBoldFirstline: indexPath.row == 0
+                )
                 cell.seeMoreTapped = { [weak self] in
                     guard let self = self else { return }
                     self.viewModel.operationInfoSeeMoreTapped(indexPath: indexPath)

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -297,19 +297,19 @@ extension StoreDetailViewController: UICollectionViewDelegate {
             scrollView.contentSize.height - scrollView.frame.size.height + collectionView.contentInset.bottom {
             navigationController?.navigationBar.tintColor = .black
             moveToTopButton.isHidden = true
-            if #available(iOS 15, *) {} else {
+            if #unavailable(iOS 15) {
                 navigationController?.navigationBar.isHidden = false
             }
         } else if scrollView.contentOffset.y > 0 {
             navigationController?.navigationBar.tintColor = .black
             moveToTopButton.isHidden = false
-            if #available(iOS 15, *) {} else {
+            if #unavailable(iOS 15) {
                 navigationController?.navigationBar.isHidden = false
             }
         } else {
             navigationController?.navigationBar.tintColor = .white
             moveToTopButton.isHidden = true
-            if #available(iOS 15, *) {} else {
+            if #unavailable(iOS 15) {
                 navigationController?.navigationBar.isHidden = true
             }
         }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -514,8 +514,7 @@ extension StoreDetailViewController {
                 let shouldShowMore = self.viewModel.operationInfoSeeMoreIndexPaths.contains(indexPath)
                 cell.setUpContents(
                     operation: operationInfo,
-                    shouldShowMore: shouldShowMore,
-                    shouldBoldFirstline: indexPath.row == 0
+                    shouldShowMore: shouldShowMore
                 )
                 cell.seeMoreTapped = { [weak self] in
                     guard let self = self else { return }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -68,6 +68,16 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
         viewModel.viewDidLoad()
     }
 
+    override func viewDidLayoutSubviews() {
+        if view.safeAreaInsets.bottom == 0 {
+            backButton.snp.remakeConstraints {
+                $0.top.equalTo(view).inset(30)
+                $0.leading.equalToSuperview().inset(16)
+            }
+            view.layoutIfNeeded()
+        }
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         tabBarController?.tabBar.isHidden = true
         viewModel.viewWillAppear()
@@ -148,7 +158,6 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
 
         backButton.snp.makeConstraints {
             $0.top.equalToSuperview().inset(58)
-            $0.top.equalToSuperview().inset(10).priority(.low)
             $0.leading.equalToSuperview().inset(16)
         }
     }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -38,6 +38,17 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
         return button
     }()
 
+    private lazy var backButton: UIButton = {
+        let button = UIButton()
+        let backButtonImage = Asset.Images.iconArrowLeft.image.withRenderingMode(.alwaysTemplate)
+        button.setImage(backButtonImage, for: .normal)
+        button.tintColor = .white
+        if #available(iOS 15, *) {
+            button.isHidden = true
+        }
+        return button
+    }()
+
     init(viewModel: StoreDetailViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -123,7 +134,7 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
     }
 
     private func layout() {
-        [collectionView, moveToTopButton].forEach { view.addSubview($0) }
+        [collectionView, moveToTopButton, backButton].forEach { view.addSubview($0) }
 
         collectionView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalToSuperview()
@@ -133,6 +144,12 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
             $0.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(8)
             $0.width.height.equalTo(52)
+        }
+
+        backButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(58)
+            $0.top.equalToSuperview().inset(10).priority(.low)
+            $0.leading.equalToSuperview().inset(16)
         }
     }
 
@@ -298,12 +315,14 @@ extension StoreDetailViewController: UICollectionViewDelegate {
             navigationController?.navigationBar.tintColor = .black
             moveToTopButton.isHidden = true
             if #unavailable(iOS 15) {
+                backButton.isHidden = true
                 navigationController?.navigationBar.isHidden = false
             }
         } else if scrollView.contentOffset.y > 0 {
             navigationController?.navigationBar.tintColor = .black
             moveToTopButton.isHidden = false
             if #unavailable(iOS 15) {
+                backButton.isHidden = true
                 navigationController?.navigationBar.isHidden = false
             }
         } else {
@@ -311,6 +330,7 @@ extension StoreDetailViewController: UICollectionViewDelegate {
             moveToTopButton.isHidden = true
             if #unavailable(iOS 15) {
                 navigationController?.navigationBar.isHidden = true
+                backButton.isHidden = false
             }
         }
     }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -51,6 +51,7 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        setUpNavigationBar()
         setUpCollectionView()
         layout()
         bind()
@@ -58,7 +59,6 @@ final class StoreDetailViewController: UIViewController, ServerAlertable, LoginA
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        setUpNavigationBar()
         tabBarController?.tabBar.isHidden = true
         viewModel.viewWillAppear()
     }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewModel/StoreDetailViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewModel/StoreDetailViewModel.swift
@@ -73,14 +73,10 @@ final class StoreDetailViewModel {
         + store.notice
 
         return [
-            OperationInfo(image: Asset.Images.iconClock.image.withRenderingMode(.alwaysTemplate),
-                          content: businessHourInfo),
-            OperationInfo(image: Asset.Images.iconOperationCall.image.withRenderingMode(.alwaysTemplate),
-                          content: store.phoneNumber),
-            OperationInfo(image: Asset.Images.iconOperationLink.image.withRenderingMode(.alwaysTemplate),
-                          content: store.snsAddress),
-            OperationInfo(image: Asset.Images.iconLocation.image.withRenderingMode(.alwaysTemplate),
-                          content: store.address)
+            OperationInfo(type: .time, content: businessHourInfo),
+            OperationInfo(type: .phoneNumber, content: store.phoneNumber),
+            OperationInfo(type: .link, content: store.snsAddress),
+            OperationInfo(type: .address, content: store.address)
         ].filter {
             !$0.content.isEmpty
         }

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewModel/StoreDetailViewModel.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewModel/StoreDetailViewModel.swift
@@ -166,7 +166,7 @@ final class StoreDetailViewModel {
                 let products = try await fetchProductsUseCase.execute(requestValue: .init(storeId: store.storeId))
                 self.products = products
                 setUpCategories()
-                applyDataSource?()
+                applyDataSourceWithoutAnimation?()
             } catch NetworkError.exception(errorMessage: let message) {
                 showErrorAlert?(message, nil)
             } catch {
@@ -183,7 +183,7 @@ final class StoreDetailViewModel {
                 if self.reviews != reviews {
                     self.reviews = reviews
                     setUpRankedTags()
-                    applyDataSource?()
+                    applyDataSourceWithoutAnimation?()
                 }
             } catch NetworkError.exception(errorMessage: let message) {
                 showErrorAlert?(message, nil)
@@ -200,7 +200,7 @@ final class StoreDetailViewModel {
                 let response = try await fetchStoreRecommendUseCase.execute(requestValue: requestValue)
                 store.didUserRecommended = response.didRecommended
                 store.recommendedCount = response.recommendCount
-                applyDataSource?()
+                applyDataSourceWithoutAnimation?()
             } catch NetworkError.exception(errorMessage: let message) {
                 showErrorAlert?(message, nil)
             } catch {


### PR DESCRIPTION
## 🧴 PR 요약
-  운영정보 탭의 매장 링크를 누르면 링크가 열리도록 하는 기능을 구현했습니다.
- 운영 시간의 첫줄은 bold처리 되도록 수정했습니다.
- 네트워크 서비스의 15.0 최소지원 메서드를 사용하던 부분을 버전별로 분기처리 해주었습니다.
- ios 15 미만 버전에선 UINavigationBarAppearance의 scrollEdgeAppearance가 적용되지 않기에 이에 대응하는 코드를 추가했습니다.

#### 📌 변경 사항
- 리뷰 쓰기 화면의 가게정보 셀의 상단 마진이 적용되지 않아있던 문제를 수정했습니다.

### 링크 열기 동작 화면

https://user-images.githubusercontent.com/67148595/220087467-9fb4277b-b605-4cc2-940b-4c0bd3d1b95d.mov

#### Linked Issue
close #206 
